### PR TITLE
Labels

### DIFF
--- a/clients/py/tests/test_v3io_frames.py
+++ b/clients/py/tests/test_v3io_frames.py
@@ -101,20 +101,25 @@ def test_read():
 
 def test_encode_df():
     c = v3f.Client('http://localhost:8080')
+    labels = {
+        'int': 7,
+        'str': 'wassup?',
+    }
 
     df = pd.read_csv('{}/weather.csv'.format(here))
-    data = c._encode_df(df)
+    data = c._encode_df(df, labels)
     msg = msgpack.unpackb(data, raw=False)
 
     assert set(msg['columns']) == set(df.columns), 'columns mismatch'
     cols = set(msg['slice_cols']) | set(msg['label_cols'])
     assert cols == set(df.columns), 'columns mismatch (in slice or label)'
     assert not msg['index_name'], 'has index'
+    assert msg['labels'] == labels, 'lables mismatch'
 
     # Now with index
     index_name = 'DATE'
     df.index = df.pop(index_name)
-    data = c._encode_df(df)
+    data = c._encode_df(df, None)
     msg = msgpack.unpackb(data, raw=False)
 
     all_names = set(df.columns) | {index_name}

--- a/frameimpl.go
+++ b/frameimpl.go
@@ -158,8 +158,8 @@ func (mf *frameImpl) Slice(start int, end int) (Frame, error) {
 	return NewFrame(frameSlice, mf.IndexName(), mf.labels)
 }
 
-// MapFrameMessage is over-the-wire frame data
-type MapFrameMessage struct {
+// FrameMessage is over-the-wire frame data
+type FrameMessage struct {
 	Columns   []string                       `msgpack:"columns"`
 	IndexName string                         `msgpack:"index_name,omitempty"`
 	Labels    map[string]interface{}         `msgpack:"labels,omitempty"`
@@ -169,11 +169,12 @@ type MapFrameMessage struct {
 
 // Marshal marshals to native type
 func (mf *frameImpl) Marshal() (interface{}, error) {
-	msg := &MapFrameMessage{
+	msg := &FrameMessage{
 		Columns:   mf.Names(),
 		IndexName: mf.IndexName(),
 		LabelCols: make(map[string]*LabelColumnMessage),
 		SliceCols: make(map[string]*SliceColumnMessage),
+		Labels:    mf.Labels(),
 	}
 
 	for _, col := range mf.columns {

--- a/frameimpl_test.go
+++ b/frameimpl_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 )
 
-func TestMapFrameNew(t *testing.T) {
+func TestFrameNew(t *testing.T) {
 	val0, val1, size := 7, "n", 10
 	col0, _ := NewLabelColumn("col0", val0, size)
 	col1, _ := NewLabelColumn("col1", val1, size)
@@ -67,7 +67,7 @@ func TestMapFrameNew(t *testing.T) {
 	}
 }
 
-func TestMapFrameSlice(t *testing.T) {
+func TestFrameSlice(t *testing.T) {
 	nCols, size := 7, 10
 	cols := newIntCols(t, nCols, size)
 	frame, err := NewFrame(cols, "", nil)
@@ -96,7 +96,7 @@ func TestMapFrameSlice(t *testing.T) {
 	}
 }
 
-func TestMapFrameIndex(t *testing.T) {
+func TestFrameIndex(t *testing.T) {
 	nCols, size := 2, 12
 	cols := newIntCols(t, nCols, size)
 

--- a/marshal.go
+++ b/marshal.go
@@ -86,7 +86,7 @@ func NewDecoder(reader io.Reader) *Decoder {
 
 // Decode encodes a frame
 func (d *Decoder) Decode() (Frame, error) {
-	msg := &MapFrameMessage{}
+	msg := &FrameMessage{}
 	if err := d.decoder.Decode(msg); err != nil {
 		return nil, err
 	}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -40,7 +40,7 @@ func TestMarshal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	msg, ok := out.(*MapFrameMessage)
+	msg, ok := out.(*FrameMessage)
 	if !ok {
 		t.Fatalf("wrong message type - %T", msg)
 	}
@@ -66,6 +66,9 @@ func TestRoundTrip(t *testing.T) {
 		t.Fatalf("columns mismatch: %v != %v", cols1, cols2)
 	}
 
+	if mapsEqual(frame1.Labels(), frame2.Labels()) {
+		t.Fatalf("labels mismatch: %v != %v", frame1.Labels(), frame2.Labels())
+	}
 }
 
 func createFrame(t *testing.T) Frame {
@@ -104,10 +107,34 @@ func createFrame(t *testing.T) Frame {
 	}
 
 	columns = append(columns, col)
-	frame, err := NewFrame(columns, "", nil)
+	labels := map[string]interface{}{
+		"x": 1,
+		"y": "hello",
+	}
+
+	frame, err := NewFrame(columns, "", labels)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	return frame
+}
+
+func mapsEqual(m1, m2 map[string]interface{}) bool {
+	if len(m1) != len(m2) {
+		return false
+	}
+
+	for key, value1 := range m1 {
+		value2, ok := m2[key]
+		if !ok {
+			return false
+		}
+
+		if value1 != value2 {
+			return false
+		}
+	}
+
+	return true
 }

--- a/server/server.go
+++ b/server/server.go
@@ -264,6 +264,7 @@ func (s *Server) handleWrite(ctx *fasthttp.RequestCtx) {
 			}
 
 			s.logger.DebugWith("frame to write", "size", frame.Len())
+			s.logger.DebugWith("labels", "labels", frame.Labels())
 			if err := appender.Add(frame); err != nil {
 				s.logger.ErrorWith("can't add frame", "error", err)
 				ctx.Error(err.Error(), http.StatusInternalServerError)

--- a/server/server.go
+++ b/server/server.go
@@ -264,7 +264,6 @@ func (s *Server) handleWrite(ctx *fasthttp.RequestCtx) {
 			}
 
 			s.logger.DebugWith("frame to write", "size", frame.Len())
-			s.logger.DebugWith("labels", "labels", frame.Labels())
 			if err := appender.Add(frame); err != nil {
 				s.logger.ErrorWith("can't add frame", "error", err)
 				ctx.Error(err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Support labels in Python client and some Lables related tests.

Manually tested the Python client with adding a debug log for labels in the server and then running

```python
import v3io_frames as v3f
import pandas as pd

df = pd.read_csv('_t/companylist.csv')
labels = {
    'x': 1,
    'y': 'hi there',
}

c = v3f.Client('http://localhost:8080', '')
c.write('weather', 'companies', df, labels=labels)
```