### PR TITLE
IG-11266: Sort dataframe columns on read.

### DIFF
--- a/clients/py/v3io_frames/pbutils.py
+++ b/clients/py/v3io_frames/pbutils.py
@@ -100,6 +100,7 @@ def msg2df(frame, frame_factory):
 
     i = 0
     is_range = True
+    df.columns = df.columns.sort_values()
     for name in df.columns:
         try:
             if name.startswith('column_') and int(name[len('column_'):]) == i:

--- a/clients/py/v3io_frames/pbutils.py
+++ b/clients/py/v3io_frames/pbutils.py
@@ -100,7 +100,7 @@ def msg2df(frame, frame_factory):
 
     i = 0
     is_range = True
-    df.columns = df.columns.sort_values()
+    df = df.reindex(sorted(df.columns), axis=1)
     for name in df.columns:
         try:
             if name.startswith('column_') and int(name[len('column_'):]) == i:


### PR DESCRIPTION
As KV attributes have no defined order, we sometimes get the columns in an order other than the one intended (e.g. `column_2, column_1, column_0`). In such a case, we need to sort the columns to be able to identify data for a range dataframe correctly.