### PR TITLE
IG-12726: Fix panic when reading KV with specific columns containing index

### DIFF
--- a/backends/kv/reader.go
+++ b/backends/kv/reader.go
@@ -23,6 +23,7 @@ package kv
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/v3io/frames"
 	"github.com/v3io/frames/backends"
 	"github.com/v3io/frames/backends/utils"

--- a/backends/kv/reader.go
+++ b/backends/kv/reader.go
@@ -22,6 +22,7 @@ package kv
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/v3io/frames"
 	"github.com/v3io/frames/backends"
 	"github.com/v3io/frames/backends/utils"
@@ -70,17 +71,18 @@ func (kv *Backend) Read(request *frames.ReadRequest) (frames.FrameIterator, erro
 		return nil, err
 	}
 
-	newKVIter := Iterator{request: request, iter: iter, keyColumnName: schema.Key}
+	newKVIter := Iterator{request: request, iter: iter, keyColumnName: schema.Key, shouldDuplicateIndex: containsString(columns, schema.Key)}
 	return &newKVIter, nil
 }
 
 // Iterator is key/value iterator
 type Iterator struct {
-	request       *frames.ReadRequest
-	iter          *v3ioutils.AsyncItemsCursor
-	err           error
-	currFrame     frames.Frame
-	keyColumnName string
+	request              *frames.ReadRequest
+	iter                 *v3ioutils.AsyncItemsCursor
+	err                  error
+	currFrame            frames.Frame
+	keyColumnName        string
+	shouldDuplicateIndex bool
 }
 
 // Next advances the iterator to next frame
@@ -170,8 +172,16 @@ func (ki *Iterator) Next() bool {
 		indexCol, ok := byName[ki.keyColumnName]
 		if ok {
 			delete(byName, ki.keyColumnName)
-			indices = []frames.Column{indexCol}
-			columns = utils.RemoveColumn(ki.keyColumnName, columns)
+
+			// If a user requested specific columns containing the index, duplicate the index column
+			// to be an index and a column
+			if ki.shouldDuplicateIndex {
+				dupIndex := indexCol.CopyWithName(fmt.Sprintf("_%v", ki.keyColumnName))
+				indices = []frames.Column{dupIndex}
+			} else {
+				indices = []frames.Column{indexCol}
+				columns = utils.RemoveColumn(ki.keyColumnName, columns)
+			}
 		}
 	}
 
@@ -199,4 +209,14 @@ func init() {
 	if err := backends.Register("kv", NewBackend); err != nil {
 		panic(err)
 	}
+}
+
+func containsString(s []string, subString string) bool {
+	for _, str := range s {
+		if str == subString {
+			return true
+		}
+	}
+
+	return false
 }

--- a/column.go
+++ b/column.go
@@ -319,6 +319,16 @@ func (c *colImpl) Append(value interface{}) error {
 	return c.appendSlice(value)
 }
 
+func (c *colImpl) CopyWithName(newName string) Column {
+	var newCol Column
+	newColImpl := *c
+	newCol = &newColImpl
+	newMsg := *c.msg
+	newColImpl.msg = &newMsg
+	newColImpl.msg.Name = newName
+	return newCol
+}
+
 // NewSliceColumn returns a new slice column
 func NewSliceColumn(name string, data interface{}) (Column, error) {
 	msg := &pb.Column{

--- a/column.go
+++ b/column.go
@@ -320,9 +320,8 @@ func (c *colImpl) Append(value interface{}) error {
 }
 
 func (c *colImpl) CopyWithName(newName string) Column {
-	var newCol Column
 	newColImpl := *c
-	newCol = &newColImpl
+	newCol := &newColImpl
 	newMsg := *c.msg
 	newColImpl.msg = &newMsg
 	newColImpl.msg.Name = newName

--- a/types.go
+++ b/types.go
@@ -54,6 +54,7 @@ type Column interface {
 	Bools() ([]bool, error)                   // Data as []bool
 	BoolAt(i int) (bool, error)               // bool value at index i
 	Slice(start int, end int) (Column, error) // Slice of data
+	CopyWithName(newName string) Column       // Create a copy of the current column
 }
 
 // Frame is a collection of columns


### PR DESCRIPTION
if a user requested specific columns on kv read, and one of them is the index col, duplicate the index column to be as both index and regular column. the index name would be  `_<indexname>`