### PR TITLE
IG-12559 && IG-12671

### DIFF
--- a/backends/kv/reader.go
+++ b/backends/kv/reader.go
@@ -229,9 +229,11 @@ func (kv *Backend) getPartitions(path string, container v3io.Container) ([]strin
 	for !done {
 		input := &v3io.GetContainerContentsInput{Path: path, DirectoriesOnly: true, Marker: marker}
 		res, err := container.GetContainerContentsSync(input)
-		res.Release() // Releasing underlying fasthttp response
 		if err != nil {
 			return nil, err
+		}
+		if res != nil {
+			res.Release() // Releasing underlying fasthttp response
 		}
 		out := res.Output.(*v3io.GetContainerContentsOutput)
 		if len(out.CommonPrefixes) > 0 {

--- a/backends/utils/utils.go
+++ b/backends/utils/utils.go
@@ -151,13 +151,8 @@ func ColAt(col frames.Column, i int) (interface{}, error) {
 		return col.FloatAt(i)
 	case frames.StringType:
 		return col.StringAt(i)
-	case frames.TimeType: // TODO: Does v3io support time.Time?
-		asTime, err := col.TimeAt(i)
-		if err != nil {
-			return nil, err
-		}
-		return asTime.Format(time.RFC3339Nano), nil // store as time string since v3io doesnt have native time format
-		//return col.TimeAt(i), nil
+	case frames.TimeType:
+		return col.TimeAt(i)
 	case frames.BoolType:
 		return col.BoolAt(i)
 	default:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/tinylib/msgp v1.1.0 // indirect
-	github.com/v3io/v3io-go v0.0.0-20190804122140-7a7baa9fe04ff8591cb4b22270d598b36fc0d49a
+	github.com/v3io/v3io-go v0.0.0-20190708180000-beb22c4a945d8f1d9765639a06b2116756146b15
 	github.com/v3io/v3io-tsdb v0.9.6
 	github.com/valyala/fasthttp v1.2.0
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/v3io/frames v0.0.0-20190328123118-1dad1ff610509e7b087d9cd390ed1b452ca
 github.com/v3io/sqlparser v0.0.0-20190306105200-4d7273501871 h1:myF4tU/HdFWU1UzMdf16cHRbownzsyvL7VKIHqkrSvo=
 github.com/v3io/sqlparser v0.0.0-20190306105200-4d7273501871/go.mod h1:QD2Bo64oyTWzeV8RFehXS0hZEDFgOK99/h2a6ErRu6E=
 github.com/v3io/v3io-go v0.0.0-20180415000000-1486c75b0e590a14580f7d9b6cef7a944a231ca7/go.mod h1:MHc+d/Jg/y8lV4B9sgwTvuS3tEE9wS+kqtU0+D0Sr78=
-github.com/v3io/v3io-go v0.0.0-20190804122140-7a7baa9fe04ff8591cb4b22270d598b36fc0d49a h1:3xiuabjd2Qy1auDKeqJfkaASmsn0UEtrtwUeJKYZ5O4=
-github.com/v3io/v3io-go v0.0.0-20190804122140-7a7baa9fe04ff8591cb4b22270d598b36fc0d49a/go.mod h1:IFb6dJiyvJnOjXUoCoPJ5UViaYjgVYmqJb4fD1qDeLk=
+github.com/v3io/v3io-go v0.0.0-20190708180000-beb22c4a945d8f1d9765639a06b2116756146b15 h1:BpFK417nsy36IWMQAJtYz5vjr1WZiJUXh8qMYCWgqx8=
+github.com/v3io/v3io-go v0.0.0-20190708180000-beb22c4a945d8f1d9765639a06b2116756146b15/go.mod h1:IFb6dJiyvJnOjXUoCoPJ5UViaYjgVYmqJb4fD1qDeLk=
 github.com/v3io/v3io-go-http v0.0.0-20190221115935-53e2b487c9a2 h1:NJc63wM25iS+ci5z7LVwjWD4QM0QpTQw/fovKzatss0=
 github.com/v3io/v3io-go-http v0.0.0-20190221115935-53e2b487c9a2/go.mod h1:GXYcR9MxgfbE3BJdkXki5EclvtS8Nxu2RQNLA8hMMog=
 github.com/v3io/v3io-tsdb v0.0.0-20190328071546-4e85f3df2d205fc7368d54184bb2ceff949ab4bd/go.mod h1:A+5yKC16QxLf+Fy5v7VvIxSw+jwsKHLhUS7dCYFDLAA=

--- a/v3ioutils/schema.go
+++ b/v3ioutils/schema.go
@@ -36,7 +36,7 @@ const (
 	LongType   = "long"
 	DoubleType = "double"
 	StringType = "string"
-	TimeType   = "time"
+	TimeType   = "timestamp"
 	BoolType   = "boolean"
 )
 


### PR DESCRIPTION
support v3io timestamps in both read and write of kv.

depends on `v3io-go` support, implemented in - https://github.com/v3io/v3io-go/pull/26