### PR TITLE
IG-12938

### DIFF
--- a/backends/kv/writer.go
+++ b/backends/kv/writer.go
@@ -22,14 +22,14 @@ package kv
 
 import (
 	"fmt"
-	"github.com/nuclio/logger"
-	v3io "github.com/v3io/v3io-go/pkg/dataplane"
 	"strings"
 	"time"
 
+	"github.com/nuclio/logger"
 	"github.com/v3io/frames"
 	"github.com/v3io/frames/backends/utils"
 	"github.com/v3io/frames/v3ioutils"
+	v3io "github.com/v3io/v3io-go/pkg/dataplane"
 )
 
 // Appender is key/value appender


### PR DESCRIPTION
handle false false as info message.
Currently engine changed their error formatting and it's from the following format:
```
{
    "ErrorCode": -184549378,
    "ErrorMessage": "UpdateItem: ConditionExpression result is false. Item was not updated",
    "ExtraInfo": {
        "error_0": {
            "ErrorCode": -385875972,
            "ErrorMessage": "Expression error: Attribute doesn't exist"
        },
        "error_1": {
            "ErrorCode": -385876025,
            "ErrorMessage": "Expression error: Key not found for condition"
        }
    }
}
```

Basically we want to ignore only this error -  `ErrorMessage": "Expression error: Key not found for condition`

Later we would need to also change `v3io-go` to support the "new" engine error format