### PR TITLE
[DOC-REVIEW] Frames README & help text (#3): Overview, user-auth, Client constructor, Create, and Write params doc imprv; misc cosmetics

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ All Frames backends that support the `create` method support the following commo
 The following `tsdb` backend parameters are passed via the [`attrs`](#method-create-param-attrs) parameter of the `create` method; for more information about these parameters, see the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb):
 
 - <a id="method-create-tsdb-param-rate"></a>**rate** &mdash; The ingestion rate of the TSDB metric samples.
-  The rate should be calculated according to the slowest expected ingestion rate.
+  It's recommended that you set the rate to the average expected ingestion rate and that ingestion rates for a given TSDB table don't vary significantly; when there's a big difference in the ingestion rates (for example, x10), use separate TSDB tables.
 
   - **Type:** `str`
   - **Requirement:** Required

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This can be done by using any of the following alternative methods (documented i
 - <a id="user-auth-client-const-params"></a>Provide the authentication credentials in the [`Client` constructor parameters](#client-constructor-parameters) by using either of the following methods:
 
   - <a id="user-auth-token"></a>Set the [`token`](#client-param-token) constructor parameter to a valid platform access key with the required data-access permissions.
+    You can get the access key from the **Access Keys** window that's available from the user-profile menu of the platform dashboard, or by copying the value of the `V3IO_ACCESS_KEY` environment variable in a platform web-shell or Jupyter Notebook service.
   - <a id="user-auth-user-password"></a>Set the [`user`](#client-param-user) and [`password`](#client-param-password) constructor parameters to the username and password of a platform user with the required data-access permissions.
   <br/>
 
@@ -78,13 +79,13 @@ This can be done by using any of the following alternative methods (documented i
 - <a id="user-auth-client-envar"></a>Set the authentication credentials in environment variables, by using either of the following methods:
 
   - <a id="user-auth-client-envar-access-key"></a>Set the `V3IO_ACCESS_KEY` environment variable to a valid platform access key with the required data-access permissions.
+
+    > **Note:** The platform's Jupyter Notebook service automatically defines the `V3IO_ACCESS_KEY` environment variable and initializes it to a valid access key for the running user of the service. 
   - <a id="user-auth-client-envar-user-pwd"></a>Set the `V3IO_USERNAME` and `V3IO_PASSWORD` environment variables to the username and password of a platform user with the required data-access permissions.
-  <br/>
 
   > **Note:**
-  > - When the client constructor is called with [authentication parameters](#user-auth-client-const-params), the authentication-credentials environment variables (if defined) are ignored.
+  > - When the client constructor is called with authentication parameters ([option #1](#user-auth-client-const-params)), the authentication-credentials environment variables (if defined) are ignored.
   > - When `V3IO_ACCESS_KEY` is defined, `V3IO_USERNAME` and `V3IO_PASSWORD` are ignored.
-  > - The platform's Jupyter Notebook service automatically defines the `V3IO_ACCESS_KEY` environment variable and initializes it to a valid access key for the running user of the service. 
 
 <a id="client-constructor"></a>
 ### Client Constructor

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ All client methods receive the following common parameters; additional, method-s
 
   - **Type:** `str`
   - **Requirement:** Required
-  - **Valid Values:** `"csv"` (for testing) | `"kv"` | `"stream"` | `"tsdb"`
+  - **Valid Values:**  `"kv"` | `"stream"` | `"tsdb"` | `"csv"` (for testing)
 
 - <a id="client-method-param-table"></a>**table** &mdash; The relative path to the backend data &mdash; a directory in the target platform data container (as configured for the client object) that represents a TSDB or NoSQL table or a data stream.
   For example, `"mytable"` or `"examples/tsdb/my_metrics"`.

--- a/README.md
+++ b/README.md
@@ -213,30 +213,12 @@ The `create` method is supported by the `tsdb` and `stream` backends, but not by
 
 <a id="method-create-syntax"></a>
 #### Syntax
-<!-- [IntInfo] (26.9.19) (sharonl) We omitted `schema=None` because the
-  `schema` parameter is used only with the `csv` testing backend. -->
-
-<a id="method-create-syntax-tsdb"></a>
-##### `tsdb` Backend
-
-```python
-create(backend, table, attrs=None)
-```
-
-```python
-attrs={"rate": ""[, "aggregates": "", "aggregation-granularity": ""]}
-```
-
-<a id="method-create-syntax-stream"></a>
-##### `stream` Backend
 
 ```python
 create(backend, table[, attrs=None])
 ```
-
-```python
-attrs={["shards": 1, "retention_hours": 24]}
-```
+<!-- [IntInfo] (26.9.19) (sharonl) We omitted `schema=None` because the
+  `schema` parameter is used only with the `csv` testing backend. -->
 
 <a id="method-create-common-params"></a>
 #### Common `create` Parameters
@@ -246,7 +228,7 @@ All Frames backends that support the `create` method support the following commo
 - <a id="method-create-param-attrs"></a>**attrs** &mdash; A dictionary of `<argument name>: <value>` pairs for passing additional backend-specific parameters (arguments).
 
   - **Type:** `dict`
-  - **Requirement:** Optional
+  - **Requirement:** Required for the `tsdb` backend; optional otherwise
   - **Valid Values:** The valid values are backend-specific.
     See [tsdb Backend create Parameters](#method-create-params-tsdb) and [stream Backend create Parameters](#method-create-params-stream).
   - **Default Value:** `None`

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The following examples, for local platform execution, both create a Frames clien
 
 ```python
 import v3io_frames as v3f
-client = v3f.Client("framesd:8081", user="iguazio", token="e8bd4ca2-537b-4175-bf01-8c74963e90bf", container="users")
+client = v3f.Client("framesd:8081", token="e8bd4ca2-537b-4175-bf01-8c74963e90bf", container="users")
 ```
 
 ```python

--- a/README.md
+++ b/README.md
@@ -352,12 +352,21 @@ write(backend, table, dfs, condition="", labels=None, max_in_message=0,
 All Frames backends that support the `write` method support the following common parameters:
 
 - <a id="method-write-param-dfs"></a>**dfs** (Required) &mdash; A single DataFrame, a list of DataFrames, or a DataFrames iterator &mdash; One or more DataFrames containing the data to write.
+
+  For the `tsdb` backend, for each DataFrame &mdash;
+
+  - You must define an index column whose value is the sample time of the data.
+    This column serves as the table's primary-key attribute.
+    Note that a TSDB DataFrame cannot have more than one index column of a time data type.
+  - You can optionally define additional string index columns for metric labels.
+    Note that you can also define labels by using the [`labels`](#method-write-tsdb-param-labels) parameter, in addition or instead of using column indexes.
+
 - <a id="method-write-param-index_cols"></a>**index_cols** (Optional) (default: `None`) &mdash; `[]str` &mdash; A list of column (attribute) names to be used as index columns for the write operation, regardless of any index-column definitions in the DataFrame.
   By default, the DataFrame's index columns are used.
   <br/>
   > **Note:** The significance and supported number of index columns is backend specific.
   > For example, the `kv` backend supports only a single index column for the primary-key item attribute, while the `tsdb` backend supports additional index columns for metric labels.
-- <a id="method-write-param-labels"></a>**labels** (Optional) (default: `None`) &mdash; This parameter is currently defined for all backends but is used only for the TSDB backend, therefore it's documented as part of the `write` method's [`tsdb` backend parameters](#method-write-params-tsdb).
+- <a id="method-write-param-labels"></a>**labels** (Optional) &mdash; This parameter is currently applicable only to the `tsdb` backend (although it's available for all backends) and is therefore documented as part of the `write` method's [`tsdb` backend parameters](#method-write-tsdb-param-labels).
 - <a id="method-write-param-max_in_message"></a>**max_in_message** (Optional) (default: `0`)
 - <a id="method-writse-param-partition_keys"></a>**partition_keys** (Optional) (default: `None`) &mdash; `[]str` &mdash; [**Not supported in this version**]
 
@@ -387,8 +396,10 @@ v3c.write(backend="kv", table="mytable", dfs=df, expression="city='NY'", conditi
 
 The following `write` parameters are specific to the `tsdb` backend; for more information about these parameters, see the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb):
 
-- <a id="method-write-param-labels"></a>**labels** (Optional) (default: `None`) &mdash; `dict` &mdash; A dictionary of `<label name>: <label value>` pairs that define metric labels to add to all written metric-sample table items.
-  Note that the values of the metric labels must be of type string.
+- <a id="method-write-tsdb-param-labels"></a>**labels** (Optional) (default: `None`) &mdash; `dict` &mdash;
+A dictionary of metric labels for the written item (row) of the format `{<label>: <value>[, <label>: <value>, ...]}`.
+  For example, `{"os": "linux", "arch": "x86"}`.
+  Note that you can also define labels by using DataFrame index columns, in addition or instead of using the `labels` parameter, as explained in the description of the [`dfs`](#method-write-param-dfs) parameter.
 
 <a id="method-write-examples"></a>
 #### `write` Examples

--- a/README.md
+++ b/README.md
@@ -16,16 +16,23 @@ V3IO Frames (**"Frames"**) is a multi-model open-source data-access library, dev
 
 - [Overview](#overview)
 - [User Authentication](#user-authentication)
-- [Client Constructor](#client-constructor)
-- [Common Client Method Parameters](#client-common-method-params)
-- [create Method](#method-create)
-- [write Method](#method-write)
-- [read Method](#method-read)
-- [delete Method](#method-delete)
-- [execute Method](#method-execute)
+- [`Client` Constructor](#client-constructor)
+- [Common `Client` Method Parameters](#client-common-method-params)
+- [`create` Method](#method-create)
+- [`write` Method](#method-write)
+- [`read` Method](#method-read)
+- [`delete` Method](#method-delete)
+- [`execute` Method](#method-execute)
 
 <a id="api-reference-overview"></a>
 ### Overview
+
+- [Initialization](#initialization)
+- [`Client` Methods](#client-methods)
+- [Backend Types](#backend-types)
+
+<a id="initialization"></a>
+#### Initialization
 
 To use Frames, you first need to import the **v3io_frames** Python library.
 For example:
@@ -36,7 +43,7 @@ Then, you need to create and initialize an instance of the `Client` class; see [
 You can then use the client methods to perform different data operations on the supported backend types:
 
 <a id="client-methods"></a>
-#### Client Methods
+#### `Client` Methods
 
 The `Client` class features the following methods for supporting basic data operations:
 
@@ -88,7 +95,7 @@ This can be done by using any of the following alternative methods (documented i
   > - When `V3IO_ACCESS_KEY` is defined, `V3IO_USERNAME` and `V3IO_PASSWORD` are ignored.
 
 <a id="client-constructor"></a>
-### Client Constructor
+### `Client` Constructor
 
 All Frames operations are executed via an object of the `Client` class.
 
@@ -168,7 +175,7 @@ client = v3f.Client("framesd:8081", user="iguazio", password="mypass", container
 ```
 
 <a id="client-common-method-params"></a>
-### Common Client Method Parameters
+### Common `Client` Method Parameters
 
 All client methods receive the following common parameters; additional, method-specific parameters are described for each method.
 
@@ -186,7 +193,7 @@ All client methods receive the following common parameters; additional, method-s
   - **Requirement:** Required unless otherwise specified in the method-specific documentation
 
 <a id="method-create"></a>
-### create Method
+### `create` Method
 
 Creates a new TSDB table or stream in a platform data container, according to the specified backend type.
 
@@ -196,6 +203,7 @@ The `create` method is supported by the `tsdb` and `stream` backends, but not by
 - [Common parameters](#method-create-common-params)
 - [`tsdb` backend `create` parameters](#method-create-params-tsdb)
 - [`stream` backend `create` parameters](#method-create-params-stream)
+- [Examples](#method-create-examples)
 
 <a id="method-create-syntax"></a>
 #### Syntax
@@ -203,7 +211,7 @@ The `create` method is supported by the `tsdb` and `stream` backends, but not by
   `schema` parameter is used only with the `csv` testing backend. -->
 
 <a id="method-create-syntax-tsdb"></a>
-##### tsdb Backend
+##### `tsdb` Backend
 
 ```python
 create(backend, table, attrs=None)
@@ -214,7 +222,7 @@ attrs={"rate": ""[, "aggregates": "", "aggregation-granularity": ""]}
 ```
 
 <a id="method-create-syntax-stream"></a>
-##### stream Backend
+##### `stream` Backend
 
 ```python
 create(backend, table[, attrs=None])
@@ -225,7 +233,7 @@ attrs={["shards": 1, "retention_hours": 24]}
 ```
 
 <a id="method-create-common-params"></a>
-#### Common create Parameters
+#### Common `create` Parameters
 
 All Frames backends that support the `create` method support the following common parameters:
 
@@ -238,7 +246,7 @@ All Frames backends that support the `create` method support the following commo
   - **Default Value:** `None`
 
 <a id="method-create-params-tsdb"></a>
-#### tsdb Backend create Parameters
+#### `tsdb` Backend `create` Parameters
 
 The following `tsdb` backend parameters are passed via the [`attrs`](#method-create-param-attrs) parameter of the `create` method; for more information about these parameters, see the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb):
 
@@ -247,7 +255,7 @@ The following `tsdb` backend parameters are passed via the [`attrs`](#method-cre
 
   - **Type:** `str`
   - **Requirement:** Required
-  - **Valid Values:** A string of the format `"[0-9]+/[smh]"` &mdash; where `s` = seconds, `m` = minutes, and `h` = hours.
+  - **Valid Values:** A string of the format `"[0-9]+/[smh]"` &mdash; where '`s`' = seconds, '`m`' = minutes, and '`h`' = hours.
     For example, `"1/s"` (one sample per minute), `"20/m"` (20 samples per minute), or `"50/h"` (50 samples per hour).
 
 - <a id="method-create-tsdb-param-aggregates"></a>**aggregates** &mdash; Default aggregates to calculate in real time during the samples ingestion.
@@ -261,27 +269,11 @@ The following `tsdb` backend parameters are passed via the [`attrs`](#method-cre
 
   - **Type:** `str`
   - **Requirement:** Optional
-  - **Valid Values:** A string of the format `"[0-9]+[mhd]"` &mdash; where `m` = minutes, `h` = hours, and `d` = days.
+  - **Valid Values:** A string of the format `"[0-9]+[mhd]"` &mdash; where '`m`' = minutes, '`h`' = hours, and '`d`' = days.
     For example, `"30m"` (30 minutes), `"2h"` (2 hours), or `"1d"` (1 day).
 
-<a id="method-create-params-tsdb-examples"></a>
-###### Examples
-
-- Create a TSDB table named "mytable" in the root directory of the client's data container with an ingestion rate of 10 samples per minute:
-
-  ```python
-  client.create("tsdb", "/mytable", attrs={"rate": "10/m"})
-  ```
-
-- Create a TSDB table named "my_metrics" in a **tsdb** directory in the client's data container with an ingestion rate of 1 sample per second.
- The table is created with the `count`, `avg`, `min`, and `max` aggregates and an aggregation interval of 1 hour:
-
-  ```python
-  client.create("tsdb", "/tsdb/my_metrics", attrs={"rate": "1/s", "aggregates": "count,avg,min,max", "aggregation-granularity": "1h"})
-  ```
-
 <a id="method-create-params-stream"></a>
-#### stream Backend create Parameters
+#### `stream` Backend `create` Parameters
 
 The following `stream` backend parameters are passed via the [`attrs`](#method-create-param-attrs) parameter of the `create` method; for more information about these parameters, see the [platform streams documentation](https://www.iguazio.com/docs/concepts/latest-release/streams):
 
@@ -299,8 +291,27 @@ The following `stream` backend parameters are passed via the [`attrs`](#method-c
   - **Default Value:** `24`
   - **Valid Values:** A positive integer (>= 1).
 
-<a id="method-create-params-stream-examples"></a>
-###### Examples
+<a id="method-create-examples"></a>
+#### `create` Examples
+
+<a id="method-create-examples-tsdb"></a>
+##### `tsdb` Backend
+
+- Create a TSDB table named "mytable" in the root directory of the client's data container with an ingestion rate of 10 samples per minute:
+
+  ```python
+  client.create("tsdb", "/mytable", attrs={"rate": "10/m"})
+  ```
+
+- Create a TSDB table named "my_metrics" in a **tsdb** directory in the client's data container with an ingestion rate of 1 sample per second.
+ The table is created with the `count`, `avg`, `min`, and `max` aggregates and an aggregation interval of 1 hour:
+
+  ```python
+  client.create("tsdb", "/tsdb/my_metrics", attrs={"rate": "1/s", "aggregates": "count,avg,min,max", "aggregation-granularity": "1h"})
+  ```
+
+<a id="method-create-examples-stream"></a>
+##### `stream` Backend
 
 - Create a stream named "mystream" in the root directory of the client's data container.
   The stream has 6 shards and a retention period of 1 hour (default):
@@ -317,7 +328,7 @@ The following `stream` backend parameters are passed via the [`attrs`](#method-c
   ```
 
 <a id="method-write"></a>
-### write Method
+### `write` Method
 
 Writes data from a DataFrame to a table or stream in a platform data container, according to the specified backend type.
 
@@ -325,6 +336,7 @@ Writes data from a DataFrame to a table or stream in a platform data container, 
 - [Common parameters](#method-write-common-params)
 - [`tsdb` backend `write` parameters](#method-write-params-tsdb)
 - [`kv` backend `write` parameters](#method-write-params-kv)
+- [Examples](#method-write-examples)
 
 <a id="method-write-syntax"></a>
 #### Syntax
@@ -347,7 +359,7 @@ write(backend, table, dfs, condition='', labels=None, max_in_message=0,
   The returned DataFrames include a `"labels"` DataFrame attribute with backend-specific data, if applicable; for example, for the `stream` backend, this attribute holds the sequence number of the last stream record that was read.
 
 <a id="method-write-common-params"></a>
-#### Common write Parameters
+#### Common `write` Parameters
 
 All Frames backends that support the `write` method support the following common parameters:
 
@@ -361,22 +373,14 @@ All Frames backends that support the `write` method support the following common
 - <a id="method-write-param-max_in_message"></a>**max_in_message** (Optional) (default: `0`)
 - <a id="method-writse-param-partition_keys"></a>**partition_keys** (Optional) (default: `None`) &mdash; `[]str` &mdash; [**Not supported in this version**]
 
-Example:
-```python
-data = [["tom", 10], ["nick", 15], ["juli", 14]]
-df = pd.DataFrame(data, columns = ["name", "age"])
-df.set_index("name", inplace=True)
-client.write(backend="kv", table="mytable", dfs=df)
-```
-
 <a id="method-write-params-tsdb"></a>
-#### tsdb Backend write Parameters
+#### `tsdb` Backend `write` Parameters
 
 - <a id="method-write-param-labels"></a>**labels** (Optional) (default: `None`) &mdash; `dict` &mdash; A dictionary of `<label name>: <label value>` pairs that define metric labels to add to all written metric-sample table items.
   Note that the values of the metric labels must be of type string.
 
 <a id="method-write-params-kv"></a>
-#### kv Backend write Parameters
+#### `kv` Backend `write` Parameters
 
 <!--
 - <a id="method-write-kv-param-expression"></a>**expression** (Optional) (default: `None`) &mdash; A platform update expression that determines how to update the table for all items in the DataFrame.
@@ -394,7 +398,13 @@ v3c.write(backend="kv", table="mytable", dfs=df, expression="city='NY'", conditi
 - <a id="method-write-kv-param-condition"></a>**condition** (Optional) (default: `None`) &mdash; A platform condition expression that defines conditions for performing the write operation.
   For detailed information about platform condition expressions, see the [platform documentation](https://www.iguazio.com/docs/reference/latest-release/expressions/condition-expression/).
 
-Example:
+<a id="method-write-examples"></a>
+#### `write` Examples
+
+<a id="method-write-examples-kv"></a>
+##### `kv` Backend
+<!-- TODO: Add example descriptions. -->
+
 ```python
 data = [["tom", 10, "TLV"], ["nick", 15, "Berlin"], ["juli", 14, "NY"]]
 df = pd.DataFrame(data, columns = ["name", "age", "city"])
@@ -402,8 +412,16 @@ df.set_index("name", inplace=True)
 v3c.write(backend="kv", table="mytable", dfs=df, condition="age>14")
 ```
 
+<!-- TODO: Add examples.
+<a id="method-write-examples-tsdb"></a>
+##### `tsdb` Backend
+
+<a id="method-stream-examples-tsdb"></a>
+##### `stream` Backend
+-->
+
 <a id="method-read"></a>
-### read Method
+### `read` Method
 
 Reads data from a table or stream in a platform data container to a DataFrame, according to the configured backend.
 
@@ -413,6 +431,7 @@ Reads data from a table or stream in a platform data container to a DataFrame, a
 - [`kv` backend `read` parameters](#method-read-params-kv)
 - [`stream` backend `read` parameters](#method-read-params-stream)
 - [Return Value](#method-read-return-value)
+- [Examples](#method-read-examples)
 
 Reads data from a backend.
 
@@ -426,14 +445,15 @@ read(backend='', table='', query='', columns=None, filter='', group_by='',
 ```
 
 <a id="method-read-common-params"></a>
-#### Common read Parameters
+#### Common `read` Parameters
 
 All Frames backends that support the `read` method support the following common parameters:
 
 - <a id="method-read-param-iterator"></a>**iterator** &mdash; (Optional) (default: `False`) &mdash; `bool` &mdash; `True` to return a DataFrames iterator; `False` to return a single DataFrame.
 - <a id="method-read-param-filter"></a>**filter** (Optional) &mdash; `str` &mdash; A query filter.
+  For example, `filter="col1=='my_value'"`.
   <br/>
-  This parameter can't be used concurrently with the `query` parameter. Example: `filter="col1=='my_value'"`
+  This parameter can't be used concurrently with the `query` parameter.
 - <a id="method-read-param-columns"></a>**columns** &mdash; `[]str` &mdash; A list of attributes (columns) to return.
   <br/>
   This parameter can't be used concurrently with the `query` parameter.
@@ -443,7 +463,7 @@ All Frames backends that support the `read` method support the following common 
 - <a id="method-read-param-row_layout"></a>**row_layout** (Optional) (default: `False`) &mdash; `bool` &mdash; `True` to use a row layout; `False` (default) to use a column layout. [**Not supported in this version**]
 
 <a id="method-read-params-tsdb"></a>
-#### tsdb Backend read Parameters
+#### `tsdb` Backend `read` Parameters
 
 - <a id="method-read-tsdb-param-start"></a>**start** &mdash; `str` &mdash; Start (minimum) time for the read operation, as a string containing an RFC 3339 time, a Unix timestamp in milliseconds, a relative time of the format `"now"` or `"now-[0-9]+[mhd]"` (where `m` = minutes, `h` = hours, and `'d'` = days), or 0 for the earliest time.
   For example: `"2016-01-02T15:34:26Z"`; `"1451748866"`; `"now-90m"`; `"0"`.
@@ -468,13 +488,8 @@ All Frames backends that support the `read` method support the following common 
 
 For detailed information about these parameters, refer to the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb).
 
-Example:
-```python
-df = client.read(backend="tsdb", query="select avg(cpu) as cpu, avg(diskio), avg(network) from mytable where os='win'", start="now-1d", end="now", step="2h")
-```
-
 <a id="method-read-params-kv"></a>
-#### kv Backend read Parameters
+#### `kv` Backend `read` Parameters
 
 - <a id="method-read-kv-param-reset_index"></a>**reset_index** &mdash; `bool` &mdash; Reset the index. When set to `false` (default), the DataFrame will have the key column of the v3io kv as the index column.
   When set to `true`, the index will be reset to a range index.
@@ -487,13 +502,8 @@ df = client.read(backend="tsdb", query="select avg(cpu) as cpu, avg(diskio), avg
 
 For detailed information about these parameters, refer to the platform's NoSQL documentation.
 
-Example:
-```python
-df = client.read(backend="kv", table="mytable", filter="col1>666")
-```
-
 <a id="method-read-params-stream"></a>
-#### stream Backend read Parameters
+#### `stream` Backend `read` Parameters
 
 - <a id="method-read-stream-param-seek"></a>**seek** &mdash; `str` &mdash; Valid values:  `"time" | "seq"/"sequence" | "latest" | "earliest"`.
   <br/>
@@ -504,11 +514,6 @@ df = client.read(backend="kv", table="mytable", filter="col1>666")
 - <a id="method-read-stream-param-sequence"></a>**sequence** &mdash; `int64` (Optional)
 
 For detailed information about these parameters, refer to the [platform streams documentation](https://www.iguazio.com/docs/concepts/latest-release/streams).
-
-Example:
-```python
-df = client.read(backend="stream", table="mytable", seek="latest", shard_id="5")
-```
 
 <a id="method-read-return-value"></a>
 #### Return Value
@@ -524,14 +529,40 @@ df = client.read(backend="stream", table="mytable", seek="latest", shard_id="5")
   represents a unique label set, as reflected in the `labels` DF attribute, but
   when reading a single DF, it' currently unclear what `labels` should hold. -->
 
+<a id="method-read-examples"></a>
+#### `read` Examples
+<!-- TODO: Add example descriptions. -->
+
+<a id="method-read-examples-kv"></a>
+##### `kv` Backend
+
+```python
+df = client.read(backend="kv", table="mytable", filter="col1>666")
+```
+
+<a id="method-read-examples-tsdb"></a>
+##### `tsdb` Backend
+
+```python
+df = client.read(backend="tsdb", query="select avg(cpu) as cpu, avg(diskio), avg(network) from mytable where os='win'", start="now-1d", end="now", step="2h")
+```
+
+<a id="method-stream-examples-tsdb"></a>
+##### `stream` Backend
+
+```python
+df = client.read(backend="stream", table="mytable", seek="latest", shard_id="5")
+```
+
 <a id="method-delete"></a>
-### delete Method
+### `delete` Method
 
 Deletes a table or stream or specific table items from a platform data container, according to the specified backend type.
 
 - [Syntax](#method-delete-syntax)
 - [`tsdb` backend `delete` parameters](#method-delete-params-tsdb)
 - [`kv` backend `delete` parameters](#method-delete-params-kv)
+- [Examples](#method-delete-examples)
 
 <a id="method-delete-syntax"></a>
 #### Syntax
@@ -541,7 +572,7 @@ delete(backend, table, filter='', start='', end='')
 ```
 
 <a id="method-delete-params-tsdb"></a>
-#### tsdb Backend delete Parameters
+#### `tsdb` Backend `delete` Parameters
 
 - <a id="method-delete-tsdb-param-start"></a>**start** &mdash; `str` &mdash; Start (minimum) time for the delete operation, as a string containing an RFC 3339 time, a Unix timestamp in milliseconds, a relative time of the format `"now"` or `"now-[0-9]+[mhd]"` (where `m` = minutes, `h` = hours, and `'d'` = days), or 0 for the earliest time.
   For example: `"2016-01-02T15:34:26Z"`; `"1451748866"`; `"now-90m"`; `"0"`.
@@ -556,34 +587,43 @@ delete(backend, table, filter='', start='', end='')
 
 For detailed information about these parameters, refer to the [V3IO TSDB](https://github.com/v3io/v3io-tsdb#v3io-tsdb) documentation.
 
-Example:
-```python
-df = client.delete(backend="tsdb", table="mytable", start="now-1d", end="now-5h")
-```
-
 <a id="method-delete-params-kv"></a>
-#### kv Backend delete Parameters
+#### `kv` Backend `delete` Parameters
 
 - <a id="method-delete-kv-param-filter"></a>**filter** &mdash; `str` &mdash; A platform filter expression that identifies specific items to delete.
   For detailed information about platform filter expressions, see the [platform documentation](https://www.iguazio.com/docs/reference/latest-release/expressions/condition-expression/#filter-expression).
 
 > **Note:** When the `filter` parameter isn't set, the entire table is deleted.
 
-Example:
+<a id="method-delete-examples"></a>
+#### `delete` Examples
+<!-- TODO: Add example descriptions. -->
+
+<a id="method-delete-examples-kv"></a>
+##### `kv` Backend
+
 ```python
 df = client.delete(backend="kv", table="mytable", filter="age > 40")
 ```
 
+<a id="method-delete-examples-tsdb"></a>
+##### `tsdb` Backend
+
+```python
+df = client.delete(backend="tsdb", table="mytable", start="now-1d", end="now-5h")
+```
+
 <a id="method-execute"></a>
-### execute Method
+### `execute` Method
 
 Extends the basic CRUD functionality of the other client methods via backend-specific commands.
 
 - [Syntax](#method-execute-syntax)
 - [Common parameters](#method-execute-common-params)
-- [tsdb backend commands](#method-execute-tsdb-cmds)
 - [kv backend commands](#method-execute-kv-cmds)
 - [stream backend commands](#method-execute-stream-cmds)
+
+> **Note:** Currently, no `execute` commands are available for the `tsdb` backend.
 
 <a id="method-execute-syntax"></a>
 #### Syntax
@@ -593,7 +633,7 @@ execute(backend, table, command='', args=None)
 ```
 
 <a id="method-execute-common-params"></a>
-#### Common execute Parameters
+#### Common `execute` Parameters
 
 All Frames backends that support the `execute` method support the following common parameters:
 
@@ -603,13 +643,8 @@ All Frames backends that support the `execute` method support the following comm
   - **Requirement:** Optional
   - **Default Value:** `None`
 
-<a id="method-execute-tsdb-cmds"></a>
-### tsdb Backend execute Commands
-
-Currently, no `execute` commands are available for the `tsdb` backend.
-
 <a id="method-execute-kv-cmds"></a>
-### kv Backend execute Commands
+### `kv` Backend `execute` Commands
 
 - <a id="method-execute-kv-cmd-infer"></a>**infer | inferschema** &mdash; Infers the data schema of a given NoSQL table and creates a schema file for the table.
 
@@ -630,7 +665,7 @@ Currently, no `execute` commands are available for the `tsdb` backend.
   <!-- [IntInfo] [c-no-update-expression-support] -->
 
 <a id="method-execute-stream-cmds"></a>
-### stream Backend execute Commands
+### `stream` Backend `execute` Commands
 
 - <a id="method-execute-stream-cmd-put"></a>**put** &mdash; Adds records to a stream.
 

--- a/README.md
+++ b/README.md
@@ -354,15 +354,7 @@ write(backend, table, dfs, condition="", labels=None, max_in_message=0,
 All Frames backends that support the `write` method support the following common parameters:
 
 - <a id="method-write-param-dfs"></a>**dfs** (Required) &mdash; A single DataFrame, a list of DataFrames, or a DataFrames iterator &mdash; One or more DataFrames containing the data to write.
-
-  For the `tsdb` backend, for each DataFrame &mdash;
-
-  - You must define an index column whose value is the sample time of the data.
-    This column serves as the table's primary-key attribute.
-    Note that a TSDB DataFrame cannot have more than one index column of a time data type.
-  - You can optionally define additional string index columns for metric labels.
-    Note that you can also define labels by using the [`labels`](#method-write-tsdb-param-labels) parameter, in addition or instead of using column indexes.
-
+  (See the [`tsdb` backend-specific parameters](#method-write-tsdb-param-dfs).)
 - <a id="method-write-param-index_cols"></a>**index_cols** (Optional) (default: `None`) &mdash; `[]str` &mdash; A list of column (attribute) names to be used as index columns for the write operation, regardless of any index-column definitions in the DataFrame.
   By default, the DataFrame's index columns are used.
   <br/>
@@ -396,12 +388,21 @@ v3c.write(backend="kv", table="mytable", dfs=df, expression="city='NY'", conditi
 <a id="method-write-params-tsdb"></a>
 #### `tsdb` Backend `write` Parameters
 
-The following `write` parameters are specific to the `tsdb` backend; for more information about these parameters, see the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb):
+The following `write` parameter descriptions are specific to the `tsdb` backend; for more information about these parameters, see the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb):
 
-- <a id="method-write-tsdb-param-labels"></a>**labels** (Optional) (default: `None`) &mdash; `dict` &mdash;
-A dictionary of metric labels for the written item (row) of the format `{<label>: <value>[, <label>: <value>, ...]}`.
+- <a id="method-write-tsdb-param-dfs"></a>**dfs** (Required) &mdash; A single DataFrame, a list of DataFrames, or a DataFrames iterator &mdash; One or more DataFrames containing the data to write.
+  This is a common `write` parameter, but the following information is specific to the `tsdb` backend:
+
+  - You must define one or more non-index DataFrame columns that represent the sample metrics; the name of the column is the metric name and its values is the sample data (i.e., the ingested metric).
+  - You must define a single index column whose value is the sample time of the data.
+    This column serves as the table's primary-key attribute.
+    Note that a TSDB DataFrame cannot have more than one index column of a time data type.
+  - <a id="tsdb-label-index-columns"></a>You can optionally define string index columns that represent metric labels for the current DataFrame row.
+    Note that you can also define labels for all DataFrame rows by using the [`labels`](#method-write-tsdb-param-labels) parameter (in addition or instead of using column indexes to apply labels to a specific row).
+
+- <a id="method-write-tsdb-param-labels"></a>**labels** (Optional) (default: `None`) &mdash; `dict` &mdash; A dictionary of metric labels of the format `{<label>: <value>[, <label>: <value>, ...]}`, which will be applied to all the DataFrame rows (i.e., to all the ingested metric samples).
   For example, `{"os": "linux", "arch": "x86"}`.
-  Note that you can also define labels by using DataFrame index columns, in addition or instead of using the `labels` parameter, as explained in the description of the [`dfs`](#method-write-param-dfs) parameter.
+  Note that you can also define labels for a specific DataFrame row by adding a string index column to the row (in addition or instead of using the `labels` parameter to define labels for all rows), as explained in the description of the [`dfs`](#tsdb-label-index-columns) parameter.
 
 <a id="method-write-examples"></a>
 #### `write` Examples

--- a/README.md
+++ b/README.md
@@ -349,13 +349,13 @@ Writes data from a DataFrame to a table or stream in a platform data container, 
 
 <!--
 ```python
-write(backend, table, dfs, expression='', condition='', labels=None,
+write(backend, table, dfs, expression="", condition="", labels=None,
     max_in_message=0, index_cols=None, partition_keys=None)
 ```
 -->
 <!-- [c-no-update-expression-support] -->
 ```python
-write(backend, table, dfs, condition='', labels=None, max_in_message=0,
+write(backend, table, dfs, condition="", labels=None, max_in_message=0,
     index_cols=None, partition_keys=None)
 ```
 
@@ -449,8 +449,8 @@ Reads data from a backend.
 #### Syntax
 
 ```python
-read(backend='', table='', query='', columns=None, filter='', group_by='',
-    limit=0, data_format='', row_layout=False, max_in_message=0, marker='',
+read(backend="", table="", query="", columns=None, filter="", group_by="",
+    limit=0, data_format="", row_layout=False, max_in_message=0, marker="",
     iterator=False, **kw)
 ```
 
@@ -578,7 +578,7 @@ Deletes a table or stream or specific table items from a platform data container
 #### Syntax
 
 ```python
-delete(backend, table, filter='', start='', end='')
+delete(backend, table, filter="", start="", end="")
 ```
 
 <a id="method-delete-params-kv"></a>
@@ -639,7 +639,7 @@ Extends the basic CRUD functionality of the other client methods via backend-spe
 #### Syntax
 
 ```python
-execute(backend, table, command='', args=None)
+execute(backend, table, command="", args=None)
 ```
 
 <a id="method-execute-common-params"></a>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For example:
 import v3io_frames as v3f
 ```
 Then, you need to create and initialize an instance of the `Client` class; see [Client Constructor](#client-constructor).
-You can then use the client methods to perform different data operations on the supported backend types:
+You can then use the client methods to perform different data operations on the supported backend types.
 
 <a id="backend-types"></a>
 #### Backend Types

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ All Frames operations are executed via an object of the `Client` class.
 - [Syntax](#client-constructor-syntax)
 - [Parameters and Data Members](#client-constructor-parameters)
 - [Return Value](#client-constructor-return-value)
-- [Example](#client-constructor-example)
+- [Examples](#client-constructor-examples)
 
 <a id="client-constructor-syntax"></a>
 #### Syntax
@@ -128,35 +128,39 @@ Client(address='', container='', user='', password='', token='')
   - **Requirement:** Required
 
 - <a id="client-param-user"></a>**user** &mdash; The username of a platform user with permissions to access the backend data.
+  See [User Authentication](#user-authentication).
 
   - **Type:** `str`
   - **Requirement:** Required when neither the [`token`](#client-param-token) parameter or the authentication environment variables are set.
-    See [User Authentication](#user-authentication).
     <br/>
     When the `user` parameter is set, the [`password`](#client-param-password) parameter must also be set to a matching user password.
 
 - <a id="client-param-password"></a>**password** &mdash; A platform password for the user configured in the [`user`](#client-param-user) parameter.
+  See [User Authentication](#user-authentication).
 
   - **Type:** `str`
   - **Requirement:** Required when the [`user`](#client-param-user) parameter is set.
-    See [User Authentication](#user-authentication).
 
 - <a id="client-param-token"></a>**token** &mdash; A valid platform access key that allows access to the backend data.
-  To get this access key, select the user profile icon on any platform dashboard page, select **Access Tokens**, and copy an existing access key or create a new key.
+  See [User Authentication](#user-authentication).
 
   - **Type:** `str`
   - **Requirement:** Required when neither the [`user`](#client-param-user) or [`password`](#client-param-password) parameters or the authentication environment variables are set.
-    See [User Authentication](#user-authentication).
 
 <a id="client-constructor-return-value"></a>
 #### Return Value
 
 Returns a new Frames `Client` data object.
 
-<a id="client-constructor-example"></a>
-#### Example
+<a id="client-constructor-examples"></a>
+#### Examples
 
-The following example, for local platform execution, creates a Frames client for accessing data in the "users" container by using the authentication credentials of the user "iguazio":
+The following examples, for local platform execution, both create a Frames client for accessing data in the "users" container by using the authentication credentials of user "iguazio"; the first example uses access-key authentication while the second example uses username and password authentication (see [User Authentication](#user-authentication)):
+
+```python
+import v3io_frames as v3f
+client = v3f.Client("framesd:8081", user="iguazio", token="e8bd4ca2-537b-4175-bf01-8c74963e90bf", container="users")
+```
 
 ```python
 import v3io_frames as v3f

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ You can then use the client methods to perform different data operations on the 
 
 The `Client` class features the following methods for supporting basic data operations:
 
-- [`create`](#method-create) &mdash; creates a new TSDB table or a stream ("backend data").
-- [`delete`](#method-delete) &mdash; deletes a table or stream or specific table items
+- [`create`](#method-create) &mdash; creates a new TSDB table or stream ("backend data").
+- [`delete`](#method-delete) &mdash; deletes a table or stream or specific table items.
 - [`read`](#method-read) &mdash; reads data from a table or stream into pandas DataFrames.
 - [`write`](#method-write) &mdash; writes data from pandas DataFrames to a table or stream.
 - [`execute`](#method-execute) &mdash; executes a backend-specific command on a table or stream.
@@ -110,7 +110,7 @@ Client(address='', container='', user='', password='', token='')
   <br/>
   When running locally on the platform (for example, from a Jupyter Notebook service), set this parameter to `framesd:8081` to use the gRPC (recommended) or to `framesd:8080` to use HTTP.
   <br/>
-  When connecting to the platform remotely, set this parameter to the API address of Frames platform service of the parent tenant.
+  When connecting to the platform remotely, set this parameter to the API address of a Frames platform service in the parent tenant.
   You can copy this address from the **API** column of the V3IO Frames service on the **Services** platform dashboard page.
   <!-- [IntInfo] In platform command-line environments, such as Jupyter
     Notebook, the local-execution Frames port numbers are saved in
@@ -185,7 +185,7 @@ Additional method-specific parameters are described for each method.
 <a id="method-create"></a>
 ### create Method
 
-Creates a new TSDB table or a stream in a platform data container, according to the specified backend type.
+Creates a new TSDB table or stream in a platform data container, according to the specified backend type.
 
 The `create` method is supported by the `tsdb` and `stream` backends, but not by the `kv` backend, because NoSQL tables in the platform don't need to be created prior to ingestion; when ingesting data into a table that doesn't exist, the table is automatically created.
 

--- a/README.md
+++ b/README.md
@@ -170,22 +170,20 @@ client = v3f.Client("framesd:8081", user="iguazio", password="mypass", container
 <a id="client-common-method-params"></a>
 ### Common Client Method Parameters
 
-All client methods receive the following common parameters:
+All client methods receive the following common parameters; additional, method-specific parameters are described for each method.
 
 - <a id="client-method-param-backend"></a>**backend** &mdash; The backend data type for the operation.
-  See the backend-types descriptions in the [overview](#backend-types).
+  See [Backend Types](#backend-types).
 
   - **Type:** `str`
-  - **Valid Values:** `"csv"` | `"kv"` | `"stream"` | `"tsdb"`
+  - **Valid Values:** `"csv"` (for testing) | `"kv"` | `"stream"` | `"tsdb"`
   - **Requirement:** Required
 
-- <a id="client-method-param-table"></a>**table** &mdash; The relative path to the backend data &mdash; A directory in the target platform data container (as configured for the client object) that represents a TSDB or NoSQL table or a data stream.
+- <a id="client-method-param-table"></a>**table** &mdash; The relative path to the backend data &mdash; a directory in the target platform data container (as configured for the client object) that represents a TSDB or NoSQL table or a data stream.
   For example, `"mytable"` or `"examples/tsdb/my_metrics"`.
 
   - **Type:** `str`
   - **Requirement:** Required unless otherwise specified in the method-specific documentation
-
-Additional method-specific parameters are described for each method.
 
 <a id="method-create"></a>
 ### create Method

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ All Frames backends that support the `create` method support the following commo
 The following `tsdb` backend parameters are passed via the [`attrs`](#method-create-param-attrs) parameter of the `create` method; for more information about these parameters, see the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb):
 
 - <a id="method-create-tsdb-param-rate"></a>**rate** &mdash; The ingestion rate of the TSDB metric samples.
-  It's recommended that you set the rate to the average expected ingestion rate and that ingestion rates for a given TSDB table don't vary significantly; when there's a big difference in the ingestion rates (for example, x10), use separate TSDB tables.
+  It's recommended that you set the rate to the average expected ingestion rate, and that the ingestion rates for a given TSDB table don't vary significantly; when there's a big difference in the ingestion rates (for example, x10), use separate TSDB tables.
 
   - **Type:** `str`
   - **Requirement:** Required

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ V3IO Frames (**"Frames"**) is a multi-model open-source data-access library, dev
 ### Overview
 
 - [Initialization](#initialization)
-- [`Client` Methods](#client-methods)
 - [Backend Types](#backend-types)
+- [`Client` Methods](#client-methods)
 
 <a id="initialization"></a>
 #### Initialization
@@ -41,18 +41,6 @@ import v3io_frames as v3f
 ```
 Then, you need to create and initialize an instance of the `Client` class; see [Client Constructor](#client-constructor).
 You can then use the client methods to perform different data operations on the supported backend types:
-
-<a id="client-methods"></a>
-#### `Client` Methods
-
-The `Client` class features the following methods for supporting basic data operations:
-
-- [`create`](#method-create) &mdash; creates a new TSDB table or stream ("backend data").
-- [`delete`](#method-delete) &mdash; deletes a table or stream or specific table items.
-- [`read`](#method-read) &mdash; reads data from a table or stream into pandas DataFrames.
-- [`write`](#method-write) &mdash; writes data from pandas DataFrames to a table or stream.
-- [`execute`](#method-execute) &mdash; executes a backend-specific command on a table or stream.
-  Each backend may support multiple commands.
 
 <a id="backend-types"></a>
 #### Backend Types
@@ -66,7 +54,19 @@ Frames supports the following backend types:
 - `csv` &mdash; a comma-separated-value (CSV) file.
   This backend type is used only for testing purposes.
 
-> **Note:** Some method parameters are common to all backend types and some are backend-specific, as detailed in this reference.
+<a id="client-methods"></a>
+#### `Client` Methods
+
+The `Client` class features the following methods for supporting basic data operations:
+
+- [`create`](#method-create) &mdash; creates a new TSDB table or stream ("backend data").
+- [`delete`](#method-delete) &mdash; deletes a table or stream or specific table items.
+- [`read`](#method-read) &mdash; reads data from a table or stream into pandas DataFrames.
+- [`write`](#method-write) &mdash; writes data from pandas DataFrames to a table or stream.
+- [`execute`](#method-execute) &mdash; executes a backend-specific command on a table or stream.
+  Each backend may support multiple commands.
+
+> **Note:** Some methods or method parameters are backend-specific, as detailed in this reference.
 
 <a id="user-authentication"></a>
 ### User Authentication

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ All Frames operations are executed via an object of the `Client` class.
 #### Syntax
 
 ```python
-Client(address='', container='', user='', password='', token='')
+Client(address=""[, data_url=""], container=""[, user="", password="", token=""])
 ```
 
 <a id="client-constructor-parameters"></a>
@@ -127,6 +127,12 @@ Client(address='', container='', user='', password='', token='')
 
   - **Type:** `str`
   - **Requirement:** Required 
+
+- <a id="client-param-data_url"></a>**data_url** &mdash; A web-API base URL for accessing the backend data.
+    By default, the client uses the data URL that's configured for the Frames service, which is typically the HTTPS URL of the web-APIs service of the parent platform tenant.
+
+  - **Type:** `str`
+  - **Requirement:** Optional
 
 - <a id="client-param-container"></a>**container** &mdash; The name of the platform data container that contains the backend data.
   For example, `"bigdata"` or `"users"`.

--- a/README.md
+++ b/README.md
@@ -340,8 +340,8 @@ Writes data from a DataFrame to a table or stream in a platform data container, 
 
 - [Syntax](#method-write-syntax)
 - [Common parameters](#method-write-common-params)
-- [`tsdb` backend `write` parameters](#method-write-params-tsdb)
 - [`kv` backend `write` parameters](#method-write-params-kv)
+- [`tsdb` backend `write` parameters](#method-write-params-tsdb)
 - [Examples](#method-write-examples)
 
 <a id="method-write-syntax"></a>
@@ -379,12 +379,6 @@ All Frames backends that support the `write` method support the following common
 - <a id="method-write-param-max_in_message"></a>**max_in_message** (Optional) (default: `0`)
 - <a id="method-writse-param-partition_keys"></a>**partition_keys** (Optional) (default: `None`) &mdash; `[]str` &mdash; [**Not supported in this version**]
 
-<a id="method-write-params-tsdb"></a>
-#### `tsdb` Backend `write` Parameters
-
-- <a id="method-write-param-labels"></a>**labels** (Optional) (default: `None`) &mdash; `dict` &mdash; A dictionary of `<label name>: <label value>` pairs that define metric labels to add to all written metric-sample table items.
-  Note that the values of the metric labels must be of type string.
-
 <a id="method-write-params-kv"></a>
 #### `kv` Backend `write` Parameters
 
@@ -403,6 +397,12 @@ v3c.write(backend="kv", table="mytable", dfs=df, expression="city='NY'", conditi
 
 - <a id="method-write-kv-param-condition"></a>**condition** (Optional) (default: `None`) &mdash; A platform condition expression that defines conditions for performing the write operation.
   For detailed information about platform condition expressions, see the [platform documentation](https://www.iguazio.com/docs/reference/latest-release/expressions/condition-expression/).
+
+<a id="method-write-params-tsdb"></a>
+#### `tsdb` Backend `write` Parameters
+
+- <a id="method-write-param-labels"></a>**labels** (Optional) (default: `None`) &mdash; `dict` &mdash; A dictionary of `<label name>: <label value>` pairs that define metric labels to add to all written metric-sample table items.
+  Note that the values of the metric labels must be of type string.
 
 <a id="method-write-examples"></a>
 #### `write` Examples
@@ -433,8 +433,8 @@ Reads data from a table or stream in a platform data container to a DataFrame, a
 
 - [Syntax](#method-read-syntax)
 - [Common parameters](#method-read-common-params)
-- [`tsdb` backend `read` parameters](#method-read-params-tsdb)
 - [`kv` backend `read` parameters](#method-read-params-kv)
+- [`tsdb` backend `read` parameters](#method-read-params-tsdb)
 - [`stream` backend `read` parameters](#method-read-params-stream)
 - [Return Value](#method-read-return-value)
 - [Examples](#method-read-examples)
@@ -468,6 +468,20 @@ All Frames backends that support the `read` method support the following common 
 - <a id="method-read-param-limit"></a>**limit** &mdash; `int` &mdash; The maximum number of rows to return. [**Not supported in this version**]
 - <a id="method-read-param-row_layout"></a>**row_layout** (Optional) (default: `False`) &mdash; `bool` &mdash; `True` to use a row layout; `False` (default) to use a column layout. [**Not supported in this version**]
 
+<a id="method-read-params-kv"></a>
+#### `kv` Backend `read` Parameters
+
+- <a id="method-read-kv-param-reset_index"></a>**reset_index** &mdash; `bool` &mdash; Reset the index. When set to `false` (default), the DataFrame will have the key column of the v3io kv as the index column.
+  When set to `true`, the index will be reset to a range index.
+- <a id="method-read-kv-param-max_in_message"></a>**max_in_message** &mdash; `int` &mdash; The maximum number of rows per message.
+- <a id="method-read-kv-param-"></a>**sharding_keys** &mdash; `[]string` (**Experimental**) &mdash; A list of specific sharding keys to query, for range-scan formatted tables only.
+- <a id="method-read-kv-param-segments"></a>**segments** &mdash; `[]int64` [**Not supported in this version**]
+- <a id="method-read-kv-param-total_segments"></a>**total_segments** &mdash; `int64` [**Not supported in this version**]
+- <a id="method-read-kv-param-sort_key_range_start"></a>**sort_key_range_start** &mdash; `str` [**Not supported in this version**]
+- <a id="method-read-kv-param-sort_key_range_end"></a>**sort_key_range_end** &mdash; `str` [**Not supported in this version**]
+
+For detailed information about these parameters, refer to the platform's NoSQL documentation.
+
 <a id="method-read-params-tsdb"></a>
 #### `tsdb` Backend `read` Parameters
 
@@ -493,20 +507,6 @@ All Frames backends that support the `read` method support the following common 
   <!-- [IntInfo] This parameter is available via the `kw` read parameter. -->
 
 For detailed information about these parameters, refer to the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb).
-
-<a id="method-read-params-kv"></a>
-#### `kv` Backend `read` Parameters
-
-- <a id="method-read-kv-param-reset_index"></a>**reset_index** &mdash; `bool` &mdash; Reset the index. When set to `false` (default), the DataFrame will have the key column of the v3io kv as the index column.
-  When set to `true`, the index will be reset to a range index.
-- <a id="method-read-kv-param-max_in_message"></a>**max_in_message** &mdash; `int` &mdash; The maximum number of rows per message.
-- <a id="method-read-kv-param-"></a>**sharding_keys** &mdash; `[]string` (**Experimental**) &mdash; A list of specific sharding keys to query, for range-scan formatted tables only.
-- <a id="method-read-kv-param-segments"></a>**segments** &mdash; `[]int64` [**Not supported in this version**]
-- <a id="method-read-kv-param-total_segments"></a>**total_segments** &mdash; `int64` [**Not supported in this version**]
-- <a id="method-read-kv-param-sort_key_range_start"></a>**sort_key_range_start** &mdash; `str` [**Not supported in this version**]
-- <a id="method-read-kv-param-sort_key_range_end"></a>**sort_key_range_end** &mdash; `str` [**Not supported in this version**]
-
-For detailed information about these parameters, refer to the platform's NoSQL documentation.
 
 <a id="method-read-params-stream"></a>
 #### `stream` Backend `read` Parameters
@@ -566,8 +566,8 @@ df = client.read(backend="stream", table="mytable", seek="latest", shard_id="5")
 Deletes a table or stream or specific table items from a platform data container, according to the specified backend type.
 
 - [Syntax](#method-delete-syntax)
-- [`tsdb` backend `delete` parameters](#method-delete-params-tsdb)
 - [`kv` backend `delete` parameters](#method-delete-params-kv)
+- [`tsdb` backend `delete` parameters](#method-delete-params-tsdb)
 - [Examples](#method-delete-examples)
 
 <a id="method-delete-syntax"></a>
@@ -576,6 +576,14 @@ Deletes a table or stream or specific table items from a platform data container
 ```python
 delete(backend, table, filter='', start='', end='')
 ```
+
+<a id="method-delete-params-kv"></a>
+#### `kv` Backend `delete` Parameters
+
+- <a id="method-delete-kv-param-filter"></a>**filter** &mdash; `str` &mdash; A platform filter expression that identifies specific items to delete.
+  For detailed information about platform filter expressions, see the [platform documentation](https://www.iguazio.com/docs/reference/latest-release/expressions/condition-expression/#filter-expression).
+
+> **Note:** When the `filter` parameter isn't set, the entire table is deleted.
 
 <a id="method-delete-params-tsdb"></a>
 #### `tsdb` Backend `delete` Parameters
@@ -592,14 +600,6 @@ delete(backend, table, filter='', start='', end='')
 > **Note:** When neither the `start` or `end` parameters are set, the entire TSDB table is deleted.
 
 For detailed information about these parameters, refer to the [V3IO TSDB](https://github.com/v3io/v3io-tsdb#v3io-tsdb) documentation.
-
-<a id="method-delete-params-kv"></a>
-#### `kv` Backend `delete` Parameters
-
-- <a id="method-delete-kv-param-filter"></a>**filter** &mdash; `str` &mdash; A platform filter expression that identifies specific items to delete.
-  For detailed information about platform filter expressions, see the [platform documentation](https://www.iguazio.com/docs/reference/latest-release/expressions/condition-expression/#filter-expression).
-
-> **Note:** When the `filter` parameter isn't set, the entire table is deleted.
 
 <a id="method-delete-examples"></a>
 #### `delete` Examples

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ The following `create` parameters are specific to the `stream` backend and are p
   - **Requirement:** Optional
   - **Default Value:** `1`
   - **Valid Values:** A positive integer (>= 1).
+    For example, `100`.
 
 - <a id="method-create-stream-param-retention_hours"></a>**retention_hours** &mdash; The stream's retention period, in hours.
 
@@ -278,6 +279,7 @@ The following `create` parameters are specific to the `stream` backend and are p
   - **Requirement:** Optional
   - **Default Value:** `24`
   - **Valid Values:** A positive integer (>= 1).
+    For example, `2` (2 hours).
 
 <a id="method-create-examples"></a>
 #### `create` Examples

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ All Frames backends that support the `create` method support the following commo
 <a id="method-create-params-tsdb"></a>
 #### `tsdb` Backend `create` Parameters
 
-The following `tsdb` backend parameters are passed via the [`attrs`](#method-create-param-attrs) parameter of the `create` method; for more information about these parameters, see the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb):
+The following `create` parameters are specific to the `tsdb` backend and are passed via the method's [`attrs`](#method-create-param-attrs) parameter; for more information about these parameters, see the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb):
 
 - <a id="method-create-tsdb-param-rate"></a>**rate** &mdash; The ingestion rate of the TSDB metric samples.
   It's recommended that you set the rate to the average expected ingestion rate, and that the ingestion rates for a given TSDB table don't vary significantly; when there's a big difference in the ingestion rates (for example, x10), use separate TSDB tables.
@@ -281,7 +281,7 @@ The following `tsdb` backend parameters are passed via the [`attrs`](#method-cre
 <a id="method-create-params-stream"></a>
 #### `stream` Backend `create` Parameters
 
-The following `stream` backend parameters are passed via the [`attrs`](#method-create-param-attrs) parameter of the `create` method; for more information about these parameters, see the [platform streams documentation](https://www.iguazio.com/docs/concepts/latest-release/streams):
+The following `create` parameters are specific to the `stream` backend and are passed via the method's [`attrs`](#method-create-param-attrs) parameter; for more information about these parameters, see the [platform's streams documentation](https://www.iguazio.com/docs/concepts/latest-release/streams):
 
 - <a id="method-create-stream-param-shards"></a>**shards** &mdash; The number of stream shards to create.
 
@@ -382,6 +382,8 @@ All Frames backends that support the `write` method support the following common
 <a id="method-write-params-kv"></a>
 #### `kv` Backend `write` Parameters
 
+The following `write` parameters are specific to the `kv` backend; for more information about these parameters, see the platform's NoSQL documentation:
+
 <!--
 - <a id="method-write-kv-param-expression"></a>**expression** (Optional) (default: `None`) &mdash; A platform update expression that determines how to update the table for all items in the DataFrame.
   For detailed information about platform update expressions, see the [platform documentation](https://www.iguazio.com/docs/reference/latest-release/expressions/update-expression/).
@@ -400,6 +402,8 @@ v3c.write(backend="kv", table="mytable", dfs=df, expression="city='NY'", conditi
 
 <a id="method-write-params-tsdb"></a>
 #### `tsdb` Backend `write` Parameters
+
+The following `write` parameters are specific to the `tsdb` backend; for more information about these parameters, see the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb):
 
 - <a id="method-write-param-labels"></a>**labels** (Optional) (default: `None`) &mdash; `dict` &mdash; A dictionary of `<label name>: <label value>` pairs that define metric labels to add to all written metric-sample table items.
   Note that the values of the metric labels must be of type string.
@@ -471,6 +475,8 @@ All Frames backends that support the `read` method support the following common 
 <a id="method-read-params-kv"></a>
 #### `kv` Backend `read` Parameters
 
+The following `read` parameters are specific to the `kv` backend; for more information about these parameters, see the platform's NoSQL documentation:
+
 - <a id="method-read-kv-param-reset_index"></a>**reset_index** &mdash; `bool` &mdash; Reset the index. When set to `false` (default), the DataFrame will have the key column of the v3io kv as the index column.
   When set to `true`, the index will be reset to a range index.
 - <a id="method-read-kv-param-max_in_message"></a>**max_in_message** &mdash; `int` &mdash; The maximum number of rows per message.
@@ -480,10 +486,10 @@ All Frames backends that support the `read` method support the following common 
 - <a id="method-read-kv-param-sort_key_range_start"></a>**sort_key_range_start** &mdash; `str` [**Not supported in this version**]
 - <a id="method-read-kv-param-sort_key_range_end"></a>**sort_key_range_end** &mdash; `str` [**Not supported in this version**]
 
-For detailed information about these parameters, refer to the platform's NoSQL documentation.
-
 <a id="method-read-params-tsdb"></a>
 #### `tsdb` Backend `read` Parameters
+
+The following `read` parameters are specific to the `tsdb` backend; for more information about these parameters, see the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb):
 
 - <a id="method-read-tsdb-param-start"></a>**start** &mdash; `str` &mdash; Start (minimum) time for the read operation, as a string containing an RFC 3339 time, a Unix timestamp in milliseconds, a relative time of the format `"now"` or `"now-[0-9]+[mhd]"` (where `m` = minutes, `h` = hours, and `'d'` = days), or 0 for the earliest time.
   For example: `"2016-01-02T15:34:26Z"`; `"1451748866"`; `"now-90m"`; `"0"`.
@@ -506,10 +512,10 @@ For detailed information about these parameters, refer to the platform's NoSQL d
 - <a id="method-read-tsdb-param-multi_index"></a>**multi_index** (Optional) &mdash; `bool` &mdash; `True` to receive the read results as multi-index DataFrames where the labels are used as index columns in addition to the metric sample-time primary-key attribute; `False` (default) only the timestamp will function as the index.
   <!-- [IntInfo] This parameter is available via the `kw` read parameter. -->
 
-For detailed information about these parameters, refer to the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb).
-
 <a id="method-read-params-stream"></a>
 #### `stream` Backend `read` Parameters
+
+The following `read` parameters are specific to the `stream` backend; for more information about these parameters, see the [platform's streams documentation](https://www.iguazio.com/docs/concepts/latest-release/streams):
 
 - <a id="method-read-stream-param-seek"></a>**seek** &mdash; `str` &mdash; Valid values:  `"time" | "seq"/"sequence" | "latest" | "earliest"`.
   <br/>
@@ -518,8 +524,6 @@ For detailed information about these parameters, refer to the [V3IO TSDB documen
   If the `time` seek type is set, you need to provide the desired start time via the `start` parameter.
 - <a id="method-read-stream-param-shard_id"></a>**shard_id** &mdash; `str`
 - <a id="method-read-stream-param-sequence"></a>**sequence** &mdash; `int64` (Optional)
-
-For detailed information about these parameters, refer to the [platform streams documentation](https://www.iguazio.com/docs/concepts/latest-release/streams).
 
 <a id="method-read-return-value"></a>
 #### Return Value
@@ -588,6 +592,8 @@ delete(backend, table, filter='', start='', end='')
 <a id="method-delete-params-tsdb"></a>
 #### `tsdb` Backend `delete` Parameters
 
+The following `delete` parameters are specific to the `tsdb` backend; for more information about these parameters, see the [V3IO TSDB documentation](https://github.com/v3io/v3io-tsdb#v3io-tsdb):
+
 - <a id="method-delete-tsdb-param-start"></a>**start** &mdash; `str` &mdash; Start (minimum) time for the delete operation, as a string containing an RFC 3339 time, a Unix timestamp in milliseconds, a relative time of the format `"now"` or `"now-[0-9]+[mhd]"` (where `m` = minutes, `h` = hours, and `'d'` = days), or 0 for the earliest time.
   For example: `"2016-01-02T15:34:26Z"`; `"1451748866"`; `"now-90m"`; `"0"`.
   <br/>
@@ -598,8 +604,6 @@ delete(backend, table, filter='', start='', end='')
   The default end time is `"now"`.
 
 > **Note:** When neither the `start` or `end` parameters are set, the entire TSDB table is deleted.
-
-For detailed information about these parameters, refer to the [V3IO TSDB](https://github.com/v3io/v3io-tsdb#v3io-tsdb) documentation.
 
 <a id="method-delete-examples"></a>
 #### `delete` Examples

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This can be done by using any of the following alternative methods (documented i
   - <a id="user-auth-user-password"></a>Set the [`user`](#client-param-user) and [`password`](#client-param-password) constructor parameters to the username and password of a platform user with the required data-access permissions.
   <br/>
 
-  > **Note:** You can't use both methods concurrently: setting both the `token` and `username` and `password` parameters in the same constructor call will produce an error.
+  > **Note:** You can't use both methods concurrently: setting both the `token` and `user` and `password` parameters in the same constructor call will produce an error.
 
 - <a id="user-auth-client-envar"></a>Set the authentication credentials in environment variables, by using either of the following methods:
 

--- a/clients/py/v3io_frames/__init__.py
+++ b/clients/py/v3io_frames/__init__.py
@@ -36,34 +36,41 @@ def Client(address='', data_url='', container='', path='', user='',
            password='', token='', session_id='', frame_factory=pd.DataFrame,
            concat=pd.concat):
     """Creates a new Frames client object
+    NOTE: User authentication must be done using any of the following methods:
+    setting the `token` parameter or the V3IO_ACCESS_KEY environment variable
+    to a valid access key; setting the `user` and `password` parameters or the
+    V3IO_USERNAME and V3IO_PASSWORD environment variables to a valid username
+    and a matching password.
 
     Parameters
     ----------
-    address : str
+    address (Required) : str
         Address of the Frames service (framesd). Use the grpc:// prefix for
         gRPC (default; recommended) or the http:// prefix for HTTP.
         Use `framesd:8081` (gRPC; recommended) or `framesd:8080` for local
         execution on an Iguazio Data Science Platform ("the platform").
-    data_url : str
-        Base URL for accessing the backend data
+    data_url (Optional): str
+        Web-API base URL for accessing the backend data; default: the base URL
+        configured for the Frames service, which is typically the HTTPS URL of
+        the web-APIs service of the parent platform tenant
     container : str
         Container name (session info)
     path : str
         DEPRECATED
-    user : str
-        The username of a platform user with permissions to access the backend
+    user (Optional): str
+        Username of a platform user with permissions to access the backend
         data; can't be used with `token`
-    password : str
-        A platform password for the user configured in the `user` parameter;
-        required when `user` is set; can't be used with `token`
-    token : str
-        A valid platform access key that allows access to the backend data;
-        can't be used with `user` and `password`
+    password (Required when `user` is set): str
+        Password for the user configured in the `user` parameter; can't be used
+        with `token`
+    token (Optional): str
+        Platform access key that allows access to the backend data; can't be
+        used with `user` and `password`
     session_id : str
-        Session ID
-    frame_factory : class
+        Session ID; currently, unused
+    frame_factory (Optional) : class
         DataFrame factory; currently, pandas DataFrame (default)
-    concat : function
+    concat (Optional): function
         Function for concatenating DataFrames; default: pandas concat
 
     Return Value

--- a/clients/py/v3io_frames/client.py
+++ b/clients/py/v3io_frames/client.py
@@ -153,7 +153,7 @@ class ClientBase:
         return self._write(request, dfs, labels, index_cols)
 
     def create(self, backend, table, attrs=None, schema=None, if_exists=FAIL):
-        """Creates a new TSDB table or a stream
+        """Creates a new TSDB table or stream
 
         Parameters
         ----------

--- a/clients/py/v3io_frames/client.py
+++ b/clients/py/v3io_frames/client.py
@@ -121,9 +121,10 @@ class ClientBase:
             Table to write to
         dfs : a single DataFrame, a DataFrames list, or a DataFrames iterator
             One or more DataFrames containing the data to write.
-            For the "tsdb" backend, the DF must contain a single time index
-            column for the metric sample time and can optionally contain
-            additional string index columns for metric labels.
+            For the "tsdb" backend - the DF must contain one or more non-index
+            columns for the sample metrics and a single time index column for
+            the sample time, and can optionally contain additional string index
+            columns for metric labels that apply to the current DataFrame row.
         expression : str
             A platform update expression that determines the update logic for
             all items in the DataFrame [Not supported in this version]
@@ -131,8 +132,8 @@ class ClientBase:
             A platform condition expression that defines a condition for
             performing the write operation
         labels : dict (`{<label>: <value>[, <label>: <value>, ...]}`)
-            Dictionary of labels; currently, used only with the "tsdb" backend,
-            which supports only string labels
+            Currently applicable only to the "tsdb" backend - a dictionary of
+            sample labels of type string that apply to all the DataFrame rows
         max_in_message : int
             Maximum number of rows to send per message
         index_cols : []str

--- a/clients/py/v3io_frames/client.py
+++ b/clients/py/v3io_frames/client.py
@@ -29,13 +29,13 @@ class ClientBase:
 
         Parameters
         ----------
-        address : str
+        address (Required) : str
             Address of the Frames service (framesd)
-        session : Session
+        session (Optional) : Session
             Session object
-        frame_factory : class
-            DataFrame factory; currently, pandas and cuDF are supported
-        concat : function
+        frame_factory (Optional) : class
+            DataFrame factory; currently, pandas (default) or cuDF
+        concat (Optional) : function
             Function for concatenating DataFrames; default: pandas concat
 
         Return Value
@@ -157,14 +157,14 @@ class ClientBase:
 
         Parameters
         ----------
-        backend : str
+        backend (Required) : str
             Backend name
-        table : str
+        table (Required) : str
             Table to create
-        attrs : dict
+        attrs (Required with `rate` for "tsdb"; optional for "stream") : dict
             A dictionary of backend-specific parameters (arguments)
-        schema: Schema or None
-            Table schema
+        schema (Optional) : Schema or None
+            Table schema; used for testing purposes with the "csv" backend
         if_exists : int
             One of IGNORE or FAIL
 

--- a/clients/py/v3io_frames/client.py
+++ b/clients/py/v3io_frames/client.py
@@ -25,13 +25,13 @@ FAIL = fpb.FAIL
 class ClientBase:
     def __init__(self, address, session, frame_factory=pd.DataFrame,
                  concat=pd.concat):
-        """Creates a new Frames client object
+        """Creates a new Frames base client object (for internal use)
 
         Parameters
         ----------
         address (Required) : str
             Address of the Frames service (framesd)
-        session (Optional) : Session
+        session (Optional) : object
             Session object
         frame_factory (Optional) : class
             DataFrame factory; currently, pandas (default) or cuDF

--- a/clients/py/v3io_frames/client.py
+++ b/clients/py/v3io_frames/client.py
@@ -120,15 +120,19 @@ class ClientBase:
         table : str
             Table to write to
         dfs : a single DataFrame, a DataFrames list, or a DataFrames iterator
-            DataFrames to write
+            One or more DataFrames containing the data to write.
+            For the "tsdb" backend, the DF must contain a single time index
+            column for the metric sample time and can optionally contain
+            additional string index columns for metric labels.
         expression : str
             A platform update expression that determines the update logic for
             all items in the DataFrame [Not supported in this version]
         condition : str
             A platform condition expression that defines a condition for
             performing the write operation
-        labels : dict
-            Dictionary of labels; currently, used only with the "tsdb" backend
+        labels : dict (`{<label>: <value>[, <label>: <value>, ...]}`)
+            Dictionary of labels; currently, used only with the "tsdb" backend,
+            which supports only string labels
         max_in_message : int
             Maximum number of rows to send per message
         index_cols : []str

--- a/clients/py/v3io_frames/client.py
+++ b/clients/py/v3io_frames/client.py
@@ -161,7 +161,7 @@ class ClientBase:
             Backend name
         table (Required) : str
             Table to create
-        attrs (Required with `rate` for "tsdb"; optional for "stream") : dict
+        attrs (Required for the "tsdb" backend; optional otherwise : dict
             A dictionary of backend-specific parameters (arguments)
         schema (Optional) : Schema or None
             Table schema; used for testing purposes with the "csv" backend


### PR DESCRIPTION
The current plan (approved by Adi) is to integrate the Frames doc into the Iguazio Data Science Platform doc, finish the doc-review edits as part of the platform doc, and replace the doc in the Frames GitHub  repo with a reference to the platform doc. But in the meantime, it would be good to merge the doc-review updates already prepared for the Frames repo in this PR.