### PR TITLE
IG-15061 (unverified): Avoid goroutine leak on error.

### DIFF
--- a/backends/kv/writer.go
+++ b/backends/kv/writer.go
@@ -109,7 +109,8 @@ func (kv *Backend) Write(request *frames.WriteRequest) (frames.FrameAppender, er
 	if request.ImmidiateData != nil {
 		err := appender.Add(request.ImmidiateData)
 		if err != nil {
-			return &appender, err
+			appender.Close()
+			return nil, err
 		}
 	}
 

--- a/backends/stream/writer.go
+++ b/backends/stream/writer.go
@@ -49,7 +49,8 @@ func (b *Backend) Write(request *frames.WriteRequest) (frames.FrameAppender, err
 	if request.ImmidiateData != nil {
 		err := appender.Add(request.ImmidiateData)
 		if err != nil {
-			return &appender, err
+			appender.Close()
+			return nil, err
 		}
 	}
 

--- a/backends/tsdb/writer.go
+++ b/backends/tsdb/writer.go
@@ -53,7 +53,8 @@ func (b *Backend) Write(request *frames.WriteRequest) (frames.FrameAppender, err
 	if request.ImmidiateData != nil {
 		err := newTsdbAppender.Add(request.ImmidiateData)
 		if err != nil {
-			return &newTsdbAppender, err
+			newTsdbAppender.Close()
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
It's bad practice to return both a value and an error, especially when the value requires closing.