### PR TITLE
Fix assertion messages for TestUpdateExpressionWithNullValues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9
 	github.com/golang/protobuf v1.2.0
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/kr/pretty v0.2.0 // indirect
 	github.com/nuclio/errors v0.0.1
 	github.com/nuclio/logger v0.0.1
 	github.com/nuclio/zap v0.0.2

--- a/test/kv_integration_test.go
+++ b/test/kv_integration_test.go
@@ -882,7 +882,7 @@ func (kvSuite *KvTestSuite) TestOverwriteItemNoSortingKey() {
 func (kvSuite *KvTestSuite) TestUpdateExpressionWithNullValues() {
 	table := fmt.Sprintf("kv_test_update_with_nulls_%d", time.Now().UnixNano())
 
-	index := []string{"mike", "joe", "jim"}
+	index := []string{"mike", "joe", "jim", "nil"}
 	icol, err := frames.NewSliceColumn("idx", index)
 	if err != nil {
 		kvSuite.T().Fatal(err)
@@ -940,6 +940,11 @@ func (kvSuite *KvTestSuite) TestUpdateExpressionWithNullValues() {
 	nullValues[1].NullColumns["n3"] = true
 	nullValues[1].NullColumns["n4"] = true
 
+	nullValues[3].NullColumns["n1"] = true
+	nullValues[3].NullColumns["n2"] = true
+	nullValues[3].NullColumns["n3"] = true
+	nullValues[3].NullColumns["n4"] = true
+
 	frame, err = frames.NewFrameWithNullValues(columns, []frames.Column{icol}, nil, nullValues)
 	if err != nil {
 		kvSuite.T().Fatal(err)
@@ -971,17 +976,15 @@ func (kvSuite *KvTestSuite) TestUpdateExpressionWithNullValues() {
 		case "mike":
 			kvSuite.Require().Nil(currentRow.GetField("n1"),
 				"item %v - key n1 supposed to be null but got %v", key, currentRow.GetField("n1"))
-
 			kvSuite.Require().NotNil(currentRow.GetField("n2"),
-				"item %v - key n2 supposed to be null but got %v", key, currentRow.GetField("n2"))
+				"item %v - key n2 should not be nil. actual value: %v", key, currentRow.GetField("n2"))
 			kvSuite.Require().NotNil(currentRow.GetField("n3"),
-				"item %v - key n3 supposed to be null but got %v", key, currentRow.GetField("n3"))
+				"item %v - key n3 should not be nil. actual value: %v", key, currentRow.GetField("n3"))
 			kvSuite.Require().NotNil(currentRow.GetField("n4"),
-				"item %v - key n4 supposed to be null but got %v", key, currentRow.GetField("n4"))
+				"item %v - key n4 should not be nil. actual value: %v", key, currentRow.GetField("n4"))
 		case "joe":
 			kvSuite.Require().NotNil(currentRow.GetField("n1"),
-				"item %v - key n1 supposed to be null but got %v", key, currentRow.GetField("n1"))
-
+				"item %v - key n1 should not be nil. actual value: %v", key, currentRow.GetField("n1"))
 			kvSuite.Require().Nil(currentRow.GetField("n2"),
 				"item %v - key n2 supposed to be null but got %v", key, currentRow.GetField("n2"))
 			kvSuite.Require().Nil(currentRow.GetField("n3"),
@@ -990,12 +993,21 @@ func (kvSuite *KvTestSuite) TestUpdateExpressionWithNullValues() {
 				"item %v - key n4 supposed to be null but got %v", key, currentRow.GetField("n4"))
 		case "jim":
 			kvSuite.Require().NotNil(currentRow.GetField("n1"),
-				"item %v - key n1 supposed to be null but got %v", key, currentRow.GetField("n1"))
+				"item %v - key n1 should not be nil. actual value: %v", key, currentRow.GetField("n1"))
 			kvSuite.Require().NotNil(currentRow.GetField("n2"),
-				"item %v - key n2 supposed to be null but got %v", key, currentRow.GetField("n2"))
+				"item %v - key n2 should not be nil. actual value: %v", key, currentRow.GetField("n2"))
 			kvSuite.Require().NotNil(currentRow.GetField("n3"),
-				"item %v - key n3 supposed to be null but got %v", key, currentRow.GetField("n3"))
+				"item %v - key n3 should not be nil. actual value: %v", key, currentRow.GetField("n3"))
 			kvSuite.Require().NotNil(currentRow.GetField("n4"),
+				"item %v - key n4 should not be nil. actual value: %v", key, currentRow.GetField("n4"))
+		case "nil":
+			kvSuite.Require().Nil(currentRow.GetField("n1"),
+				"item %v - key n1 supposed to be null but got %v", key, currentRow.GetField("n1"))
+			kvSuite.Require().Nil(currentRow.GetField("n2"),
+				"item %v - key n2 supposed to be null but got %v", key, currentRow.GetField("n2"))
+			kvSuite.Require().Nil(currentRow.GetField("n3"),
+				"item %v - key n3 supposed to be null but got %v", key, currentRow.GetField("n3"))
+			kvSuite.Require().Nil(currentRow.GetField("n4"),
 				"item %v - key n4 supposed to be null but got %v", key, currentRow.GetField("n4"))
 		default:
 			kvSuite.T().Fatalf("got an unexpected key '%v'", key)


### PR DESCRIPTION
change the test a little bit - watching CI

Expected data:
```  
  IDX       n1        n2        n3      n4
 [String]  [Float]   [String]  [Bool]  [Time]
------------------------------------------
  mike      nil       string    bool    time
  joe       float     nil       nil     nil
  jim       float     string    bool    time
  nil       nil       nil       nil     nil
```