### PR TITLE
Spawn more delete workers (same as update workers), for faster deletes.

### DIFF
--- a/backends/kv/backend.go
+++ b/backends/kv/backend.go
@@ -68,7 +68,7 @@ func (b *Backend) Delete(request *frames.DeleteRequest) error {
 		return err
 	}
 
-	return v3ioutils.DeleteTable(b.logger, container, path, request.Proto.Filter, b.numWorkers, request.Proto.IfMissing == frames.IgnoreError)
+	return v3ioutils.DeleteTable(b.logger, container, path, request.Proto.Filter, b.numWorkers, b.numWorkers*b.updateWorkersPerVN, request.Proto.IfMissing == frames.IgnoreError)
 	// TODO: delete the table directory entry if filter == ""
 }
 

--- a/backends/kv/writer.go
+++ b/backends/kv/writer.go
@@ -79,7 +79,7 @@ func (kv *Backend) Write(request *frames.WriteRequest) (frames.FrameAppender, er
 		switch request.SaveMode {
 		case frames.OverwriteTable:
 			// If this is the first time we writing to the table, there is nothing to delete.
-			err = v3ioutils.DeleteTable(kv.logger, container, tablePath, "", kv.numWorkers, true)
+			err = v3ioutils.DeleteTable(kv.logger, container, tablePath, "", kv.numWorkers, kv.numWorkers*kv.updateWorkersPerVN, true)
 			if err != nil {
 				return nil, fmt.Errorf("error occured while deleting table '%v', err: %v", tablePath, err)
 			}


### PR DESCRIPTION
Delete of 1M items before this change took 29s. With this change it took in 15s.