### PR TITLE
ci: increase linter time-out to 10m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,6 @@ lint: gofmt impi $(GOPATH)/bin/golangci-lint
      --disable-all --enable=deadcode --enable=goconst --enable=golint --enable=ineffassign \
      --enable=interfacer --enable=unconvert --enable=varcheck --enable=errcheck --enable=gofmt --enable=misspell \
      --enable=staticcheck --enable=gosimple --enable=govet --enable=goconst \
-     --timeout=2m \
+     --timeout=10m \
     api/... backends/... cmd/... framulate/... grpc/... http/... repeatingtask/... v3ioutils/...
 	@echo done linting


### PR DESCRIPTION
sometimes lint can takes more than 2 min for example in case when cache isn't warmed
<img width="906" alt="Screenshot 2020-07-15 13 45 13" src="https://user-images.githubusercontent.com/26582191/87536239-7567e980-c6a1-11ea-9fa3-d663b9e6c3a5.png">
