### PR TITLE
Raise grpcio version upper bound.

### DIFF
--- a/clients/py/requirements.txt
+++ b/clients/py/requirements.txt
@@ -1,6 +1,7 @@
 googleapis-common-protos>=1.5.3
-# Can be loosened, but grpcio 1.34.0 must not be used as it segfaults (1.34.1 ok).
-grpcio-tools>=1.30,<1.33
-grpcio>=1.30,<1.33
+# grpcio 1.34.0 must not be used as it segfaults (1.34.1 ok).
+# Upper limit is in order to avoid surprises with this sensitive dependency.
+grpcio-tools>=1.30,!=1.34.0,<1.42
+grpcio>=1.30,!=1.34.0,<1.42
 pandas>=0.23.4
 requests>=2.19.1


### PR DESCRIPTION
To avoid conflict with google-cloud-bigquery.