### PR TITLE
Fix deprecation error when using newer numpy versions

### DIFF
--- a/clients/py/v3io_frames/pbutils.py
+++ b/clients/py/v3io_frames/pbutils.py
@@ -232,7 +232,7 @@ def series2col_with_dtype(s, name, dtype):
     elif dtype == fpb.FLOAT:
         kw['dtype'] = fpb.FLOAT
         kw['floats'] = s
-    elif dtype == fpb.STRING:  # Pandas dtype for str is object
+    elif dtype == fpb.STRING:
         kw['strings'] = s
         kw['dtype'] = fpb.STRING
     elif dtype == fpb.BOOLEAN:
@@ -263,7 +263,7 @@ def series2col(s, name):
     elif is_float(s.dtype):
         kw['dtype'] = fpb.FLOAT
         kw['floats'] = s
-    elif s.dtype == np.object:  # Pandas dtype for str is object
+    elif s.dtype == object:
         kw['strings'] = s
         kw['dtype'] = fpb.STRING
     elif is_bool(s.dtype):
@@ -278,7 +278,7 @@ def series2col(s, name):
         kw['times'] = s.astype(np.int64)
         kw['dtype'] = fpb.TIME
     elif is_categorical_dtype(s.dtype):
-        # We assume catgorical data is strings
+        # We assume categorical data is strings
         kw['strings'] = s.astype(str)
         kw['dtype'] = fpb.STRING
     else:


### PR DESCRIPTION
Fixes the following error:
```
AttributeError: module 'numpy' has no attribute 'object'.
`np.object` was a deprecated alias for the builtin `object`. To avoid this error in existing code, use `object` by itself. Doing this will not modify any behavior and is safe.
```