### PR TITLE
Fix timestamp corruption with datetime granularity other than nanoseconds

### DIFF
--- a/clients/py/v3io_frames/pbutils.py
+++ b/clients/py/v3io_frames/pbutils.py
@@ -241,7 +241,8 @@ def series2col_with_dtype(s, name, dtype):
     elif dtype == fpb.TIME:
         s = pd.to_datetime(s, utc=True)
         s = s.dt.tz_convert('UTC')
-        kw['times'] = s.astype(np.int64)
+        # ML-6855: this results in nanoseconds regardless of datetime granularity, unlike s.astype(np.int64)
+        kw['times'] = s.apply(lambda x: x.value)
         kw['dtype'] = fpb.TIME
     elif dtype == fpb.NULL:
         kw['dtype'] = fpb.NULL


### PR DESCRIPTION
[ML-6855](https://iguazio.atlassian.net/browse/ML-6855)

[ML-6855]: https://iguazio.atlassian.net/browse/ML-6855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ