### PR TITLE
[Exception] Avoid error duplication 

### DIFF
--- a/clients/py/v3io_frames/grpc.py
+++ b/clients/py/v3io_frames/grpc.py
@@ -54,7 +54,7 @@ def grpc_raise(err_cls):
             except grpc.RpcError as gerr:
                 err = err_cls('error in {}: {}'.format(fn.__name__, gerr))
                 err.cause = gerr
-                raise err
+                raise err from None
 
         return wrapper
 


### PR DESCRIPTION
Recently, during a deployment, we encountered a situation where raising a gRPC error triggered another error, resulting in the following:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/v3io_frames/grpc.py", line 53, in wrapper
    return fn(*args, **kw)
  File "/usr/local/lib/python3.9/site-packages/v3io_frames/grpc.py", line 247, in _check_version
    resp = stub.Version(request)
  File "/usr/local/lib/python3.9/site-packages/grpc/_interceptor.py", line 277, in __call__
    response, ignored_call = self._with_call(
  File "/usr/local/lib/python3.9/site-packages/grpc/_interceptor.py", line 332, in _with_call
    return call.result(), call
  File "/usr/local/lib/python3.9/site-packages/grpc/_channel.py", line 439, in result
    raise self
  File "/usr/local/lib/python3.9/site-packages/grpc/_interceptor.py", line 315, in continuation
    response, call = self._thunk(new_method).with_call(
  File "/usr/local/lib/python3.9/site-packages/grpc/_channel.py", line 1193, in with_call
    return _end_unary_response_blocking(state, call, True, None)
  File "/usr/local/lib/python3.9/site-packages/grpc/_channel.py", line 1005, in _end_unary_response_blocking
    raise _InactiveRpcError(state)  # pytype: disable=not-instantiable
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.UNAVAILABLE
	details = "failed to connect to all addresses; last error: UNKNOWN: i<ip> Failed to connect to remote host: Connection refused"
	debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"failed to connect to all addresses; last error: UNKNOWN:<ip>: Failed to connect to remote host: Connection refused", grpc_status:14, created_time:<time>"
>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen igz_deployments.pipelines.serving.serving_pipeline_steps>", line 399, in store_data_to_cache
  File "/usr/local/lib/python3.9/site-packages/v3io_frames/__init__.py", line 114, in Client
    return cls(address, session, persist_connection,
  File "/usr/local/lib/python3.9/site-packages/v3io_frames/grpc.py", line 95, in __init__
    self._check_version()
  File "/usr/local/lib/python3.9/site-packages/v3io_frames/grpc.py", line 57, in wrapper
    raise err
 grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.UNAVAILABLE
	details = "failed to connect to all addresses; last error: UNKNOWN: i<ip> Failed to connect to remote host: Connection refused"
	debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"failed to connect to all addresses; last error: UNKNOWN:<ip>: Failed to connect to remote host: Connection refused", grpc_status:14, created_time:<time>"
```
    

After this change we will only see the second half. 