### PR TITLE
Add bash to image because containerd expects it to be present

### DIFF
--- a/cmd/framesd/Dockerfile
+++ b/cmd/framesd/Dockerfile
@@ -25,6 +25,7 @@ COPY . .
 ARG FRAMES_VERSION=unknown
 RUN GOOS=linux GOARCH=amd64 go build -ldflags="-X main.Version=${FRAMES_VERSION}" ./cmd/framesd
 RUN cp framesd /usr/local/bin
+RUN apk add bash
 
 VOLUME /etc/framesd
 ENV V3IO_GRPC_PORT=8081


### PR DESCRIPTION
[IG-23283](https://iguazio.atlassian.net/browse/IG-23283)

Following #672.

[IG-23283]: https://iguazio.atlassian.net/browse/IG-23283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ