### PR TITLE
Fix start/end time corruption when reading via HTTP client

### DIFF
--- a/clients/py/tests/test_http.py
+++ b/clients/py/tests/test_http.py
@@ -154,6 +154,14 @@ def test_format_go_time():
     assert offset == tz.utcoffset(now).total_seconds(), 'bad offset'
 
 
+# ML-10926
+def test_format_go_time_with_leading_zeroes():
+    dt = datetime.fromisoformat("2025-09-10T12:00:35.001000")
+    ts = v3f.http.format_go_time(dt)
+
+    assert ts == "2025-09-10T12:00:35.001000000+00:00"
+
+
 def new_test_client(address='', session=None):
     return v3f.HTTPClient(
         address=address or 'http://example.com',

--- a/clients/py/v3io_frames/http.py
+++ b/clients/py/v3io_frames/http.py
@@ -319,7 +319,7 @@ def format_go_time(dt):
     prefix = dt.strftime('%Y-%m-%dT%H:%M:%S')
     nsec = dt.microsecond * 1000
     tz = dt.strftime('%z') or '+0000'
-    return '{}.{}{}:{}'.format(prefix, nsec, tz[:3], tz[3:5])
+    return '{}.{:09d}{}:{}'.format(prefix, nsec, tz[:3], tz[3:5])
 
 
 def convert_go_times(d, keys):


### PR DESCRIPTION
[ML-10926](https://iguazio.atlassian.net/browse/ML-10926)

[ML-10926]: https://iguazio.atlassian.net/browse/ML-10926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ